### PR TITLE
The instructions should be numbered

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,7 @@ Install the package
 
          pip install --pre sphinx-hoverxref
 
-   .. tab:: from GitHub
+   .. tab:: from GitHubto
 
       .. prompt:: bash
 
@@ -19,7 +19,7 @@ Install the package
 
 
 Once we have the package installed,
-we have to configure it on our Sphinx documentation.
+we have  configure it on our Sphinx documentation.
 To do this, add this extension to your Sphinx's extensions in the ``conf.py`` file.
 
 .. code-block:: python


### PR DESCRIPTION
The instructions should be numbered, so the user can see exactly where they are and what step is next.
For example:
1. Install the package.
2. To configure the package on our Sphinx documentation, in  the ''conf.py" file, add the extension to the Sphinx's extensions.
3. etc.
In this case you can  get rid of the unnecessary text where you repeat yourself.