### PR TITLE
Use URL for docker-compose instance when building locally

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ if os.environ.get('READTHEDOCS') == 'True':
     hoverxref_tooltip_api_host = 'https://readthedocs.org'
 if os.environ.get('LOCAL_READTHEDOCS') == 'True':
     # Building on a local Read the Docs instance
-    hoverxref_tooltip_api_host = 'http://dev.readthedocs.io:8000'
+    hoverxref_tooltip_api_host = 'http://community.dev.readthedocs.io'
 
 hoverxref_tooltip_maxwidth = 650
 hoverxref_auto_ref = True


### PR DESCRIPTION
I'm using `LOCAL_READTHEDOCS` env variable to build it and develop
locally while using the same set of docs comming from this repo.

Now, I'm pointing `tooltip_api_host` to our new docker-compose configuration.