### PR TITLE
Test more Python & Sphinx versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
   docs
-  py{36,37}-sphinx{185,201,210,220}
+  py{36,37,38}-sphinx{185,201,210,220,231}
 
 [testenv]
 deps =
@@ -12,6 +12,7 @@ deps =
   sphinx201: sphinx==2.0.1
   sphinx210: sphinx==2.1.0
   sphinx220: sphinx==2.2.0
+  sphinx231: sphinx==2.3.1
 commands = pytest {posargs}
 
 [testenv:py37-sphinx210]


### PR DESCRIPTION
Added Python 3.8 and Sphinx 2.3.1