### PR TITLE
Include other tooltipster themes in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,7 @@ include hoverxref/_static/js/tooltipster.bundle.min.js
 include hoverxref/_static/css/tooltipster.bundle.min.css
 include hoverxref/_static/css/tooltipster-sideTip-shadow.min.css
 include hoverxref/_static/css/tooltipster.custom.css
+include hoverxref/_static/css/tooltipster-sideTip-light.min.css
+include hoverxref/_static/css/tooltipster-sideTip-borderless.min.css
+include hoverxref/_static/css/tooltipster-sideTip-noir.min.css
+include hoverxref/_static/css/tooltipster-sideTip-punk.min.css


### PR DESCRIPTION
When building the package these themes were not included and were
impossible so select via the config option.