### PR TITLE
Rename hoverxref_default_types to hoverxref_role_types

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ hoverxref_roles = [
     'confval',
 ]
 
-hoverxref_default_types = {
+hoverxref_role_types = {
     'hoverxref': 'tooltip',
     'ref': 'modal',
     'confval': 'tooltip',

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -14,7 +14,7 @@ General settings
 
 These settings are global and have effect on both, tooltips and modal dialogues.
 
-.. confval:: hoverxref_default_types
+.. confval:: hoverxref_role_types
 
    Description: Style to use by default when hover each type of reference (role).
 
@@ -36,7 +36,7 @@ These settings are global and have effect on both, tooltips and modal dialogues.
 
 .. confval:: hoverxref_default_type
 
-   Description: Default style when the specific one was not found in :confval:`hoverxref_default_types`.
+   Description: Default style when the specific one was not found in :confval:`hoverxref_role_types`.
 
    Default: ``tooltip``
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ We currently support two different types of floating windows: Tooltip and Modal.
 
       .. note::
 
-         The default style (tooltip or modal) is defined by the config :confval:`hoverxref_default_types <hoverxref_default_types>`.
+         The default style (tooltip or modal) is defined by the config :confval:`hoverxref_role_types <hoverxref_role_types>`.
 
 
    .. tab:: Tooltip style

--- a/hoverxref/domains.py
+++ b/hoverxref/domains.py
@@ -22,13 +22,13 @@ class HoverXRefBaseDomain:
             type_class = 'modal'
             classes.append(type_class)
         if not type_class:
-            type_class = env.config.hoverxref_default_types.get(typ)
+            type_class = env.config.hoverxref_role_types.get(typ)
             if not type_class:
                 default = env.config.hoverxref_default_type
                 type_class = default
                 logger.warning(
                     'Using default style for unknown typ. '
-                    'Define it in hoverxref_default_types. typ=%s style=%s',
+                    'Define it in hoverxref_role_types. typ=%s style=%s',
                     typ,
                     default,
                 )

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -251,7 +251,7 @@ def setup(app):
     app.add_config_value('hoverxref_roles', [], 'env')
     app.add_config_value('hoverxref_domains', [], 'env')
     app.add_config_value('hoverxref_ignore_refs', ['genindex', 'modindex', 'search'], 'env')
-    app.add_config_value('hoverxref_default_types', {}, 'env')
+    app.add_config_value('hoverxref_role_types', {}, 'env')
     app.add_config_value('hoverxref_default_type', 'tooltip', 'env')
     app.add_config_value('hoverxref_api_host', 'https://readthedocs.org', 'env')
 

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -179,7 +179,7 @@ def test_python_domain(app, status, warning):
         'hoverxref_default_type': 'modal',
     },
 )
-def test_default_types(app, status, warning):
+def test_default_type(app, status, warning):
     app.build()
     path = app.outdir / 'index.html'
     assert path.exists() is True


### PR DESCRIPTION
Avoid conflict with `hoverxref_default_type` (without s), and I think
it communicate better what it is. A mapping between role -> type