### PR TITLE
Translator on current builder

### DIFF
--- a/hoverxref/domains.py
+++ b/hoverxref/domains.py
@@ -52,6 +52,16 @@ class HoverXRefBaseDomain:
         return docpath
 
     def _is_ignored_ref(self, env, target):
+        # HACK: skip all references if the builder is non-html. We shouldn't
+        # have overridden the Domain in first instance at ``setup_domains``
+        # function, but at that time ``app.builder`` is not yet initialized. If
+        # we suscribe ourselves to ``builder-initied`` it's too late and our
+        # override does not take effect. Other builders (e.g. LatexBuilder) may
+        # fail with internal functions we use (e.g. builder.get_outfilename).
+        # So, we are skipping it here :(
+        if env.app.builder.format != 'html':
+            return True
+
         if target in env.config.hoverxref_ignore_refs:
             logger.info(
                 'Ignoring reference in hoverxref_ignore_refs. target=%s',

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -147,11 +147,12 @@ def setup_translators(app):
     and our own ``HoverXRefHTMLTranslatorMixin`` that includes the logic to
     ``_hoverxref`` attributes.
     """
-    for name, klass in app.registry.translators.items():
-        if app.builder.format != 'html':
-            # Skip translators that are not HTML
-            continue
 
+    if app.builder.format != 'html':
+        # do not modify non-html builders
+        return
+
+    for name, klass in app.registry.translators.items():
         translator = types.new_class(
             'HoverXRefHTMLTranslator',
             (

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -147,31 +147,31 @@ def setup_translators(app):
     and our own ``HoverXRefHTMLTranslatorMixin`` that includes the logic to
     ``_hoverxref`` attributes.
     """
-    if not app.registry.translators.items():
+    for name, klass in app.registry.translators.items():
+        if app.builder.format != 'html':
+            # Skip translators that are not HTML
+            continue
+
         translator = types.new_class(
             'HoverXRefHTMLTranslator',
             (
                 HoverXRefHTMLTranslatorMixin,
-                app.builder.default_translator_class,
+                klass,
             ),
             {},
         )
-        app.set_translator(app.builder.name, translator, override=True)
-    else:
-        for name, klass in app.registry.translators.items():
-            if app.builder.format != 'html':
-                # Skip translators that are not HTML
-                continue
+        app.set_translator(name, translator, override=True)
 
-            translator = types.new_class(
-                'HoverXRefHTMLTranslator',
-                (
-                    HoverXRefHTMLTranslatorMixin,
-                    klass,
-                ),
-                {},
-            )
-            app.set_translator(name, translator, override=True)
+    translator = types.new_class(
+        'HoverXRefHTMLTranslator',
+        (
+            HoverXRefHTMLTranslatorMixin,
+            app.builder.default_translator_class,
+        ),
+        {},
+    )
+    app.set_translator(app.builder.name, translator, override=True)
+
 
 
 def is_hoverxref_configured(app, config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+import shutil
+import pytest
+
+from .utils import srcdir, prefixdocumentsrcdir, customobjectsrcdir, pythondomainsrcdir
+
+
+@pytest.fixture(autouse=True, scope='function')
+def remove_sphinx_build_output():
+    """Remove _build/ folder, if exist."""
+    for path in (srcdir, prefixdocumentsrcdir, customobjectsrcdir, pythondomainsrcdir):
+        build_path = os.path.join(path, '_build')
+        if os.path.exists(build_path):
+            shutil.rmtree(build_path)

--- a/tests/examples/default/conf.py
+++ b/tests/examples/default/conf.py
@@ -5,3 +5,8 @@ extensions = [
     'sphinx.ext.autosectionlabel',
     'hoverxref.extension',
 ]
+
+latex_documents = [
+    (master_doc, 'test.tex', u'test Documentation',
+     u'test', 'manual'),
+]

--- a/tests/examples/default/index.rst
+++ b/tests/examples/default/index.rst
@@ -9,3 +9,10 @@ Using ``hoverxref`` (or ``ref`` if ``hoverxref_auto_ref=True``) should add an ``
 :ref:`This a :ref: to Chapter I <Chapter I>`.
 
 :hoverxref:`This a :hoverxref: to Chapter I, Section I <Section I>`.
+
+.. _example-reference:
+
+Example Reference
+-----------------
+
+This is a reference to :ref:`example-reference`.

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -1,43 +1,6 @@
-import os
 import pytest
-import shutil
 
-
-srcdir = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)),
-    'examples',
-    'default',
-)
-
-# srcdir with ``autosectionlabel_prefix_document = True`` config
-prefixdocumentsrcdir = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)),
-    'examples',
-    'prefixdocument',
-)
-
-# srcdir with ``Sphinx.add_object_type`` call
-customobjectsrcdir = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)),
-    'examples',
-    'custom-object',
-)
-
-# srcdir with ``:py:class:`` call
-pythondomainsrcdir = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)),
-    'examples',
-    'python-domain',
-)
-
-
-@pytest.fixture(autouse=True, scope='function')
-def remove_sphinx_build_output():
-    """Remove _build/ folder, if exist."""
-    for path in (srcdir, prefixdocumentsrcdir, customobjectsrcdir, pythondomainsrcdir):
-        build_path = os.path.join(path, '_build')
-        if os.path.exists(build_path):
-            shutil.rmtree(build_path)
+from .utils import srcdir, prefixdocumentsrcdir, customobjectsrcdir, pythondomainsrcdir
 
 
 @pytest.mark.sphinx(

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,0 +1,46 @@
+import inspect
+import os
+import pytest
+import shutil
+
+from hoverxref.translators import HoverXRefHTMLTranslatorMixin
+
+from .utils import srcdir
+
+
+@pytest.mark.sphinx(
+    srcdir=srcdir,
+    buildername='latex',
+    confoverrides={
+        'hoverxref_project': 'myproject',
+        'hoverxref_version': 'myversion',
+    },
+)
+def test_dont_override_translator_non_html_builder(app, status, warning):
+    app.build()
+    path = app.outdir / 'python.tex'
+    assert path.exists() is True
+    content = open(path).read()
+
+    assert app.builder.format == 'latex'
+    for name, klass in app.registry.translators.items():
+        assert not issubclass(klass, HoverXRefHTMLTranslatorMixin)
+
+
+@pytest.mark.sphinx(
+    srcdir=srcdir,
+    buildername='html',
+    confoverrides={
+        'hoverxref_project': 'myproject',
+        'hoverxref_version': 'myversion',
+    },
+)
+def test_override_translator_non_html_builder(app, status, warning):
+    app.build()
+    path = app.outdir / 'index.html'
+    assert path.exists() is True
+    content = open(path).read()
+
+    assert app.builder.format == 'html'
+    for name, klass in app.registry.translators.items():
+        assert issubclass(klass, HoverXRefHTMLTranslatorMixin)

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -2,6 +2,7 @@ import inspect
 import os
 import pytest
 import shutil
+from unittest import mock
 
 from hoverxref.translators import HoverXRefHTMLTranslatorMixin
 
@@ -44,3 +45,36 @@ def test_override_translator_non_html_builder(app, status, warning):
     assert app.builder.format == 'html'
     for name, klass in app.registry.translators.items():
         assert issubclass(klass, HoverXRefHTMLTranslatorMixin)
+
+
+@pytest.mark.sphinx(
+    srcdir=srcdir,
+    buildername='latex',
+    confoverrides={
+        'hoverxref_project': 'myproject',
+        'hoverxref_version': 'myversion',
+        'hoverxref_auto_ref': True,
+    },
+)
+def test_dont_fail_non_html_builder(app, status, warning):
+    """
+    Test our resolver is not used by non-HTML builder.
+
+    When running the build with ``latex`` as builder and
+    ``hoverxref_auto_ref=True`` it should not fail with
+
+    def _get_docpath(self, builder, docname):
+        docpath = builder.get_outfilename(docname)
+        AttributeError: 'LaTeXBuilder' object has no attribute 'get_outfilename'
+
+    LaTeXBuilder should never use our resolver.
+    """
+
+    with mock.patch('hoverxref.domains.HoverXRefBaseDomain._get_docpath') as _get_docpath:
+        app.build()
+        assert not _get_docpath.called
+    path = app.outdir / 'test.tex'
+    assert path.exists() is True
+    content = open(path).read()
+
+    assert app.builder.format == 'latex'

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -18,7 +18,7 @@ from .utils import srcdir
 )
 def test_dont_override_translator_non_html_builder(app, status, warning):
     app.build()
-    path = app.outdir / 'python.tex'
+    path = app.outdir / 'test.tex'
     assert path.exists() is True
     content = open(path).read()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,29 @@
+import os
+
+
+srcdir = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'examples',
+    'default',
+)
+
+# srcdir with ``autosectionlabel_prefix_document = True`` config
+prefixdocumentsrcdir = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'examples',
+    'prefixdocument',
+)
+
+# srcdir with ``Sphinx.add_object_type`` call
+customobjectsrcdir = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'examples',
+    'custom-object',
+)
+
+# srcdir with ``:py:class:`` call
+pythondomainsrcdir = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'examples',
+    'python-domain',
+)


### PR DESCRIPTION
We set our own translator in the translators defined by other extensions, but
also for the current builder.

It may happen that there is an extension that defines two translators for
`dirhml` and `json`, and we are going to override them --the problem comes when
`sphinx-build` is called with `-b custombuilder` since we weren't overriding it
in that case.

This commit override the ones defined by the user, but also the default one.

**NOTE:** the diff is a little tricky. I only removed an indentation level (to remove the first if) and swap the for/if blocks. There is no other changes.