### PR TITLE
Reduce one logging level

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -100,6 +100,13 @@ These settings are global and have effect on both, tooltips and modal dialogues.
 
 .. _Mathjax: http://www.sphinx-doc.org/es/master/usage/extensions/math.html#module-sphinx.ext.mathjax
 
+
+.. warning::
+
+   You shouldn't modify the following three settings (api_host, project, version) unless you know what you are doing.
+   Their defaults should be fine to build the documentation and make it work in Read the Docs.
+
+
 .. confval:: hoverxref_api_host
 
    Description: Host URL for the API to retrieve the content of the floating window

--- a/hoverxref/domains.py
+++ b/hoverxref/domains.py
@@ -26,11 +26,11 @@ class HoverXRefBaseDomain:
             if not type_class:
                 default = env.config.hoverxref_default_type
                 type_class = default
-                logger.warning(
-                    'Using default style for unknown typ. '
-                    'Define it in hoverxref_role_types. typ=%s style=%s',
-                    typ,
+                logger.info(
+                    'Using default style (%s) for unknown typ (%s). '
+                    'Define it in hoverxref_role_types.',
                     default,
+                    typ,
                 )
             classes.append(type_class)
 
@@ -84,7 +84,7 @@ class HoverXRefPythonDomainMixin(HoverXRefBaseDomain):
         docname, labelid = obj[0], name
         docpath = self._get_docpath(builder, docname)
         self._inject_hoverxref_data(env, refnode, typ, docname, docpath, labelid)
-        logger.info(
+        logger.debug(
             ':ref: _hoverxref injected: fromdocname=%s %s',
             fromdocname,
             refnode._hoverxref,
@@ -128,7 +128,7 @@ class HoverXRefStandardDomainMixin(HoverXRefBaseDomain):
         docname, labelid, _ = get_ref_xref_data(self, node, target)
         docpath = self._get_docpath(builder, docname)
         self._inject_hoverxref_data(env, refnode, typ, docname, docpath, labelid)
-        logger.info(
+        logger.debug(
             ':ref: _hoverxref injected: fromdocname=%s %s',
             fromdocname,
             refnode._hoverxref,
@@ -150,7 +150,7 @@ class HoverXRefStandardDomainMixin(HoverXRefBaseDomain):
         docname, labelid = get_ref_obj_data(self, node, typ, target)
         docpath = self._get_docpath(builder, docname)
         self._inject_hoverxref_data(env, refnode, typ, docname, docpath, labelid)
-        logger.info(
+        logger.debug(
             ':%s: _hoverxref injected: fromdocname=%s %s',
             typ,
             fromdocname,

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -188,9 +188,10 @@ def is_hoverxref_configured(app, config):
     if not project or not version:
         config.hoverxref_is_configured = False
         # ``hoverxref`` extension is not fully configured
-        logger.warning(
+        logger.info(
             'hoverxref extension is not fully configured. '
-            'Set hoverxref_project and hoverxref_version in your conf.py file.',
+            'Tooltips may not work as expected. '
+            'Check out the documentation for hoverxref_project and hoverxref_version configuration options.',
         )
 
 


### PR DESCRIPTION
Do not log warnings unless strictly needed because otherwise it breaks CIs.

Besides, I'm lowering down a logging level for debugging output.

Closes #59 