### PR TITLE
Distinguish name of extension, name of sample target file and name of…

### DIFF
--- a/docs/hoverxref_file.rst
+++ b/docs/hoverxref_file.rst
@@ -1,8 +1,8 @@
 :orphan:
 
-==================
+===================
  hoverxref_section
-==================
+===================
 
 Hi from another completely different page!
 

--- a/docs/hoverxref_file.rst
+++ b/docs/hoverxref_file.rst
@@ -1,8 +1,8 @@
 :orphan:
 
-===========
- hoverxref
-===========
+==================
+ hoverxref_section
+==================
 
 Hi from another completely different page!
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,11 +19,11 @@ We currently support two different types of floating windows: Tooltip and Modal.
 
       .. code-block:: rst
 
-         This will :hoverxref:`show a floating window <hoverxref:hoverxref>` in the linked words.
+         This will :hoverxref:`show a floating window <hoverxref_file:hoverxref_section>` in the linked words.
 
       it will be rendered to:
 
-      This will :hoverxref:`show a floating window <hoverxref:hoverxref>` in the linked words.
+      This will :hoverxref:`show a floating window <hoverxref_file:hoverxref_section>` in the linked words.
 
       .. note::
 
@@ -36,11 +36,11 @@ We currently support two different types of floating windows: Tooltip and Modal.
 
       .. code-block:: rst
 
-         This will :hoverxreftooltip:`show a tooltip <hoverxref:hoverxref>` in the linked words.
+         This will :hoverxreftooltip:`show a tooltip <hoverxref_file:hoverxref_section>` in the linked words.
 
       it will be rendered to:
 
-      This will :hoverxreftooltip:`show a tooltip <hoverxref:hoverxref>` in the linked words.
+      This will :hoverxreftooltip:`show a tooltip <hoverxref_file:hoverxref_section>` in the linked words.
 
 
    .. tab:: Modal style
@@ -49,11 +49,11 @@ We currently support two different types of floating windows: Tooltip and Modal.
 
       .. code-block:: rst
 
-         This will :hoverxrefmodal:`show a modal <hoverxref:hoverxref>` in the linked words.
+         This will :hoverxrefmodal:`show a modal <hoverxref_file:hoverxref_section>` in the linked words.
 
       it will be rendered to:
 
-      This will :hoverxrefmodal:`show a modal <hoverxref:hoverxref>` in the linked words.
+      This will :hoverxrefmodal:`show a modal <hoverxref_file:hoverxref_section>` in the linked words.
 
 .. tip::
 


### PR DESCRIPTION
… sample target section

I think the documentation is somewhat clearer if the role, the example target file and the example target section aren't all named "hoverxref". I am a Sphinx/RST beginner, currently hunting down why my hoverxref example doesn't work. Having made these changes, I can confirm that having a section "hoverxref_section" within a file "hoverxref_file" should be enough to create a findable target "hoverxref_file:hoverxref_section". It was less clear before. A new user can now easily confirm this by grepping for "hoverxref_section".

Update: Sorry, I mixed up some words in the commit message description! Please refer to this PR description.