### PR TITLE
Send `path` instead of `docpath`

### DIFF
--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -60,7 +60,7 @@ function getEmbedURL(project, version, doc, docpath, section) {
         'project': project,
         'version': version,
         'doc': doc,
-        'docpath': docpath,
+        'path': docpath,
         'section': section,
     }
     console.debug('Data: ' + JSON.stringify(params));

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -1,4 +1,5 @@
 import pytest
+import textwrap
 
 from .utils import srcdir, prefixdocumentsrcdir, customobjectsrcdir, pythondomainsrcdir
 
@@ -65,6 +66,14 @@ def test_js_render(app, status, warning):
         "animationDuration: 0",
         "content: 'Loading...'",
         "var url = 'https://readthedocs.org' + '/api/v2/embed/?' + $.param(params);",
+        textwrap.indent(textwrap.dedent("""
+        var params = {
+            'project': project,
+            'version': version,
+            'doc': doc,
+            'path': docpath,
+            'section': section,
+        }"""), '    ').strip(),
         "var sphinxtabs = false",
         "var mathjax = false",
     ]


### PR DESCRIPTION
EmbedAPI is expecting `path`, and we were sending `docpath`. This made all the links from inside the tooltip to return 404.

This was a regression introduced at b92ac36d652eeeec997e330017288d933bf002a4

@Daltz333 @Zac-HD would you please, test this PR in your documentation and let me know if this fixes your issue?

Closes #75 