### PR TITLE
Intersphinx support

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,5 +9,6 @@ python:
 
 sphinx:
   configuration: docs/conf.py
-  
+  fail_on_warning: true
+
 formats: []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ release = ''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.intersphinx',
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.mathjax',
     'sphinx_tabs.tabs',
@@ -50,6 +51,13 @@ extensions = [
     'versionwarning.extension',
     'notfound.extension',
 ]
+
+intersphinx_mapping = {
+    'readthedocs': ('https://docs.readthedocs.io/en/stable/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+}
+hoverxref_intersphinx = True
+hoverxref_intersphinx_type = 'modal'
 
 # Used when building the documentation from the terminal and using a local Read
 # the Docs instance as backend

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import datetime
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -20,7 +21,8 @@ import os
 # -- Project information -----------------------------------------------------
 
 project = 'sphinx-hoverxref'
-copyright = '2019, Manuel Kaufmann'
+year = datetime.datetime.now().year
+copyright = f'{year}, Manuel Kaufmann'
 author = 'Manuel Kaufmann'
 
 # The short X.Y version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ intersphinx_mapping = {
     'readthedocs': ('https://docs.readthedocs.io/en/stable/', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
 }
-hoverxref_intersphinx = intersphinx_mapping.keys()
+hoverxref_intersphinx = list(intersphinx_mapping.keys())
 hoverxref_intersphinx_type = 'modal'
 
 # Used when building the documentation from the terminal and using a local Read

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ intersphinx_mapping = {
     'readthedocs': ('https://docs.readthedocs.io/en/stable/', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
 }
-hoverxref_intersphinx = True
+hoverxref_intersphinx = intersphinx_mapping.keys()
 hoverxref_intersphinx_type = 'modal'
 
 # Used when building the documentation from the terminal and using a local Read

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,8 +56,14 @@ intersphinx_mapping = {
     'readthedocs': ('https://docs.readthedocs.io/en/stable/', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
 }
-hoverxref_intersphinx = list(intersphinx_mapping.keys())
-hoverxref_intersphinx_type = 'modal'
+hoverxref_intersphinx = [
+    'readthedocs',
+    'sphinx',
+]
+hoverxref_intersphinx_types = {
+    'readthedocs': 'modal',
+    'sphinx': 'tooltip',
+}
 
 # Used when building the documentation from the terminal and using a local Read
 # the Docs instance as backend

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -110,16 +110,25 @@ These settings are global and have effect on both, tooltips and modal dialogues.
 
    Default: ``{}``. It uses :confval:`hoverxref_default_type` if the intersphinx target is not defined in this config.
 
-   Type: str
+   Type: dict
 
    Example:
 
    .. code-block:: python
 
       {
-          'readthdocs': 'modal',
+          # make specific links to use a particular tooltip type
+          'readthdocs': {
+              'doc': 'modal',
+              'ref': 'tooltip',
+          },
+          'python': {
+              'class': 'modal',
+              'ref':, 'tooltip',
+          },
+
+          # make all links for Sphinx to be ``tooltip``
           'sphinx': 'tooltip',
-          'python': 'tooltip',
       }
 
 .. confval:: hoverxref_sphinxtabs

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -102,7 +102,7 @@ These settings are global and have effect on both, tooltips and modal dialogues.
    .. warning::
 
       The Sphinx's target project **must be hosted on Read the Docs** to work.
-      This is a current limitation that we may be able to remove in the future.
+      This is a current limitation that we hope to remove in the future.
 
 .. confval:: hoverxref_intersphinx_types
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -93,7 +93,7 @@ These settings are global and have effect on both, tooltips and modal dialogues.
 
 .. confval:: hoverxref_intersphinx
 
-   Description: Enable Sphinx's hoverxref extension on intersphinx targets from from ``intersphinx_mapping``.
+   Description: Enable Sphinx's hoverxref extension on intersphinx targets from ``intersphinx_mapping``.
 
    Default: ``[]``
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -104,15 +104,23 @@ These settings are global and have effect on both, tooltips and modal dialogues.
       The Sphinx's target project **must be hosted on Read the Docs** to work.
       This is a current limitation that we may be able to remove in the future.
 
-.. confval:: hoverxref_intersphinx_type
+.. confval:: hoverxref_intersphinx_types
 
    Description: Style used for intersphinx links.
 
-   Default: ``None``. It uses :confval:`hoverxref_default_type` if not defined.
-
-   Options: ``tooltip`` or ``modal``
+   Default: ``{}``. It uses :confval:`hoverxref_default_type` if the intersphinx target is not defined in this config.
 
    Type: str
+
+   Example:
+
+   .. code-block:: python
+
+      {
+          'readthdocs': 'modal',
+          'sphinx': 'tooltip',
+          'python': 'tooltip',
+      }
 
 .. confval:: hoverxref_sphinxtabs
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -91,10 +91,27 @@ These settings are global and have effect on both, tooltips and modal dialogues.
           'setting',
       ]
 
+.. confval:: hoverxref_intersphinx
+
+   Description: Whether or not enable Sphinx's hoverxref extension on intersphinx links.
+
+   Default: ``False``
+
+   Type: bool
+
+.. confval:: hoverxref_intersphinx_type
+
+   Description: Style used for intersphinx links.
+
+   Default: ``None``. It uses :confval:`hoverxref_default_type` if not defined.
+
+   Options: ``tooltip`` or ``modal``
+
+   Type: str
 
 .. confval:: hoverxref_sphinxtabs
 
-   Description: trigger an extra step to render tooltips where its content has a `Sphinx Tabs`_
+   Description: Trigger an extra step to render tooltips where its content has a `Sphinx Tabs`_
 
    Default: ``False``
 
@@ -104,7 +121,7 @@ These settings are global and have effect on both, tooltips and modal dialogues.
 
 .. confval:: hoverxref_mathjax
 
-   Description: trigger an extra step to render tooltips where its content has a `Mathjax`_
+   Description: Trigger an extra step to render tooltips where its content has a `Mathjax`_
 
    Default: ``False``
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -95,9 +95,9 @@ These settings are global and have effect on both, tooltips and modal dialogues.
 
    Description: Whether or not enable Sphinx's hoverxref extension on intersphinx links.
 
-   Default: ``False``
+   Default: ``None`` (follows :confval:`hoverxref_auto_ref`)
 
-   Type: bool
+   Type: bool or ``None``
 
 .. confval:: hoverxref_intersphinx_type
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -93,11 +93,16 @@ These settings are global and have effect on both, tooltips and modal dialogues.
 
 .. confval:: hoverxref_intersphinx
 
-   Description: Whether or not enable Sphinx's hoverxref extension on intersphinx links.
+   Description: Enable Sphinx's hoverxref extension on intersphinx targets from from ``intersphinx_mapping``.
 
-   Default: ``None`` (follows :confval:`hoverxref_auto_ref`)
+   Default: ``[]``
 
-   Type: bool or ``None``
+   Type: list
+
+   .. warning::
+
+      The Sphinx's target project **must be hosted on Read the Docs** to work.
+      This is a current limitation that we may be able to remove in the future.
 
 .. confval:: hoverxref_intersphinx_type
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,11 +34,11 @@ to do the following:
 
 .. code-block:: rst
 
-   Show a tooltip for :doc:`Read the Docs configuration file <readthedocs:config-file/v2>`.
+   Show a tooltip for :doc:`Read the Docs automation rules <readthedocs:automation-rules>`.
 
 That will render to:
 
-Show a tooltip for :doc:`Read the Docs configuration file <readthedocs:config-file/v2>`.
+Show a tooltip for :doc:`Read the Docs automation rules <readthedocs:automation-rules>`.
 
 .. warning::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,6 +22,43 @@ will render to this:
 This will :hoverxref:`show a tooltip <hoverxref:hoverxref>` in the linked words to ``hoverxref``.
 
 
+Tooltip on intersphinx content
+------------------------------
+
+Sphinx comes with a nice built-in extension called :ref:`sphinx.ext.intersphinx <sphinx:usage/extensions/intersphinx>`
+that allows to generate links to the documentation of sections in other projects.
+
+You can combine this extension with ``sphinx-hoverxref`` to show tooltips over these links to other projects.
+For example, this documentation itself configures intersphinx with Read the Docs documentation and allow us
+to do the following:
+
+.. code-block:: rst
+
+   Show a tooltip for :ref:`Read the Docs configuration file <readthedocs:config-file/v2>`.
+
+That will render to:
+
+Show a tooltip for :ref:`Read the Docs configuration file <readthedocs:config-file/v2>`.
+
+.. warning::
+
+   ``hoverxref.extension`` must be installed below ``sphinx.ext.intersphinx``
+   when adding them into ``extensions`` config. Example:
+
+   .. code-block:: python
+
+      extensions = [
+          # some extension
+          "sphinx.ext.intersphinx",
+          "hoverxref.extension",
+      ]
+
+.. note::
+
+   Keep in mind that the linked project should be hosted at Read the Docs.
+   This is a limitation that will be removed in the future.
+
+
 Tooltip on custom object
 ------------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -40,19 +40,6 @@ That will render to:
 
 Show a tooltip for :doc:`Read the Docs automation rules <readthedocs:automation-rules>`.
 
-.. warning::
-
-   ``hoverxref.extension`` must be installed below ``sphinx.ext.intersphinx``
-   when adding them into ``extensions`` config. Example:
-
-   .. code-block:: python
-
-      extensions = [
-          # some extension
-          "sphinx.ext.intersphinx",
-          "hoverxref.extension",
-      ]
-
 .. note::
 
    Keep in mind that the linked project should be hosted at Read the Docs.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -136,7 +136,7 @@ These actions are usually calling a Javascript function.
    This `may affect the rendering of tooltips`_ that includes content requiring extra rendering steps.
    **Make sure you are using Sphinx 3.4.x** if you require rendering this type of content in your tooltips.
 
-   .. _a feature to only include JS/CS in pages where they are used: https://github.com/sphinx-doc/sphinx/pull/8631
+   .. _a feature to only include JS/CSS in pages where they are used: https://github.com/sphinx-doc/sphinx/pull/8631
    .. _may affect the rendering of tooltips: https://github.com/sphinx-doc/sphinx/issues/9115
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -25,7 +25,7 @@ This will :hoverxref:`show a tooltip <hoverxref:hoverxref>` in the linked words 
 Tooltip on intersphinx content
 ------------------------------
 
-Sphinx comes with a nice built-in extension called :ref:`sphinx.ext.intersphinx <sphinx:usage/extensions/intersphinx>`
+Sphinx comes with a nice built-in extension called :doc:`sphinx.ext.intersphinx <sphinx:usage/extensions/intersphinx>`
 that allows to generate links to the documentation of sections in other projects.
 
 You can combine this extension with ``sphinx-hoverxref`` to show tooltips over these links to other projects.
@@ -34,11 +34,11 @@ to do the following:
 
 .. code-block:: rst
 
-   Show a tooltip for :ref:`Read the Docs configuration file <readthedocs:config-file/v2>`.
+   Show a tooltip for :doc:`Read the Docs configuration file <readthedocs:config-file/v2>`.
 
 That will render to:
 
-Show a tooltip for :ref:`Read the Docs configuration file <readthedocs:config-file/v2>`.
+Show a tooltip for :doc:`Read the Docs configuration file <readthedocs:config-file/v2>`.
 
 .. warning::
 

--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -55,13 +55,19 @@ function reLoadSphinxTabs() {
     };
 };
 
-function getEmbedURL(project, version, doc, docpath, section) {
-    var params = {
-        'project': project,
-        'version': version,
-        'doc': doc,
-        'path': docpath,
-        'section': section,
+function getEmbedURL(project, version, doc, docpath, section, url) {
+    if (url) {
+        var params = {
+            'url': url,
+        }
+    } else {
+        var params = {
+            'project': project,
+            'version': version,
+            'doc': doc,
+            'path': docpath,
+            'section': section,
+        }
     }
     console.debug('Data: ' + JSON.stringify(params));
     var url = '{{ hoverxref_api_host }}' + '/api/v2/embed/?' + $.param(params);
@@ -87,11 +93,12 @@ $(document).ready(function() {
             var doc = $origin.data('doc');
             var docpath = $origin.data('docpath');
             var section = $origin.data('section');
+            var url = $origin.data('url');
 
 
             // we set a variable so the data is only loaded once via Ajax, not every time the tooltip opens
             if ($origin.data('loaded') !== true) {
-                var url = getEmbedURL(project, version, doc, docpath, section);
+                var url = getEmbedURL(project, version, doc, docpath, section, url);
                 $.get(url, function(data) {
                     // call the 'content' method to update the content of our tooltip with the returned data.
                     // note: this content update will trigger an update animation (see the updateAnimation option)
@@ -160,8 +167,9 @@ $(document).ready(function() {
         var doc = element.data('doc');
         var docpath = element.data('docpath');
         var section = element.data('section');
+        var url = element.data('url');
 
-        var url = getEmbedURL(project, version, doc, docpath, section);
+        var url = getEmbedURL(project, version, doc, docpath, section, url);
         $.get(url, function(data) {
             var content = $('<div></div>');
             content.html(data['content'][0]);

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -150,6 +150,13 @@ def setup_intersphinx(app, config):
 
     https://github.com/sphinx-doc/sphinx/blob/53c1dff/sphinx/ext/intersphinx.py
     """
+
+    hoverxref_intersphinx_enabled = app.config.hoverxref_intersphinx or app.config.hoverxref_auto_ref
+    if not hoverxref_intersphinx_enabled:
+        # Do not disconnect original intersphinx missing-reference if the user
+        # does not have hoverxref intersphinx enabled
+        return
+
     if sphinx.version_info < (3, 0, 0):
         listeners = list(app.events.listeners.get('missing-reference').items())
     else:
@@ -170,10 +177,14 @@ def missing_reference(app, env, node, contnode):
     We call the original intersphinx extension and add hoverxref CSS classes
     plus the ``data-url`` to the node returned from it.
     """
+    hoverxref_intersphinx_enabled = app.config.hoverxref_intersphinx or app.config.hoverxref_auto_ref
+    if not hoverxref_intersphinx_enabled:
+        # Do nothing if the user doesn't have hoverxref intersphinx enabled
+        return
+
     newnode = sphinx_missing_reference(app, env, node, contnode)
-    intersphinx_enabled = app.config.hoverxref_intersphinx or app.config.hoverxref_auto_ref
     hoverxref_type = app.config.hoverxref_intersphinx_type or app.config.hoverxref_default_type
-    if newnode is not None and intersphinx_enabled:
+    if newnode is not None and hoverxref_intersphinx_enabled:
         classes = newnode.get('classes')
         classes.extend(['hoverxref', hoverxref_type])
         newnode.replace_attr('classes', classes)

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -150,9 +150,7 @@ def setup_intersphinx(app, config):
 
     https://github.com/sphinx-doc/sphinx/blob/53c1dff/sphinx/ext/intersphinx.py
     """
-
-    hoverxref_intersphinx_enabled = (app.config.hoverxref_intersphinx is None and app.config.hoverxref_auto_ref) or app.config.hoverxref_intersphinx
-    if not hoverxref_intersphinx_enabled:
+    if not app.config.hoverxref_intersphinx:
         # Do not disconnect original intersphinx missing-reference if the user
         # does not have hoverxref intersphinx enabled
         return
@@ -177,14 +175,14 @@ def missing_reference(app, env, node, contnode):
     We call the original intersphinx extension and add hoverxref CSS classes
     plus the ``data-url`` to the node returned from it.
     """
-    hoverxref_intersphinx_enabled = (app.config.hoverxref_intersphinx is None and app.config.hoverxref_auto_ref) or app.config.hoverxref_intersphinx
-    if not hoverxref_intersphinx_enabled:
+    if not app.config.hoverxref_intersphinx:
         # Do nothing if the user doesn't have hoverxref intersphinx enabled
         return
 
+    intersphinx_target = node['reftarget'].split(':')[0]
     newnode = sphinx_missing_reference(app, env, node, contnode)
     hoverxref_type = app.config.hoverxref_intersphinx_type or app.config.hoverxref_default_type
-    if newnode is not None and hoverxref_intersphinx_enabled:
+    if newnode is not None and intersphinx_target in app.config.hoverxref_intersphinx:
         classes = newnode.get('classes')
         classes.extend(['hoverxref', hoverxref_type])
         newnode.replace_attr('classes', classes)
@@ -316,7 +314,7 @@ def setup(app):
     app.add_config_value('hoverxref_ignore_refs', ['genindex', 'modindex', 'search'], 'env')
     app.add_config_value('hoverxref_role_types', {}, 'env')
     app.add_config_value('hoverxref_default_type', 'tooltip', 'env')
-    app.add_config_value('hoverxref_intersphinx', False, 'env')
+    app.add_config_value('hoverxref_intersphinx', [], 'env')
     app.add_config_value('hoverxref_intersphinx_type', None, 'env')
     app.add_config_value('hoverxref_api_host', 'https://readthedocs.org', 'env')
 

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -149,8 +149,6 @@ def setup_intersphinx(app, config):
     disconnect the original listener and add our custom one.
 
     https://github.com/sphinx-doc/sphinx/blob/53c1dff/sphinx/ext/intersphinx.py
-
-    Note that ``hoverxref.extension`` has to be installed **after** ``sphinx.ext.intersphinx``.
     """
     if sphinx.version_info < (3, 0, 0):
         listeners = list(app.events.listeners.get('missing-reference').items())

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -233,7 +233,12 @@ def missing_reference(app, env, node, contnode):
 
     newnode = sphinx_missing_reference(app, env, node, contnode)
     if newnode is not None and not skip_node:
-        hoverxref_type = app.config.hoverxref_intersphinx_types.get(inventory_name_matched) or app.config.hoverxref_default_type
+        hoverxref_type = app.config.hoverxref_intersphinx_types.get(inventory_name_matched)
+        if isinstance(hoverxref_type, dict):
+            # Specific style for a particular reftype
+            hoverxref_type = hoverxref_type.get(reftype)
+        hoverxref_type = hoverxref_type or app.config.hoverxref_default_type
+
         classes = newnode.get('classes')
         classes.extend(['hoverxref', hoverxref_type])
         newnode.replace_attr('classes', classes)

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -241,11 +241,6 @@ def missing_reference(app, env, node, contnode):
             'data-url': newnode.get('refuri'),
         }
 
-        # Remove ``title=`` from HTML tag to avoid showing the title of the
-        # reference when hovering, which is a little confusing
-        if 'reftitle' in  newnode:
-            del newnode['reftitle']
-
     return newnode
 
 

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -182,6 +182,12 @@ def missing_reference(app, env, node, contnode):
         newnode._hoverxref = {
             'data-url': newnode.get('refuri'),
         }
+
+        # Remove ``title=`` from HTML tag to avoid showing the title of the
+        # reference when hovering, which is a little confusing
+        if 'reftitle' in  newnode:
+            del newnode['reftitle']
+
     return newnode
 
 

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -197,6 +197,7 @@ def missing_reference(app, env, node, contnode):
     # By default we skip adding hoverxref to the node to avoid possible
     # problems. We want to be sure we have to add hoverxref on it
     skip_node = True
+    inventory_name_matched = None
 
     if domain == 'std':
         # Using ``:ref:`` manually, we could write intersphinx like:
@@ -210,6 +211,7 @@ def missing_reference(app, env, node, contnode):
             inventory_name, _ = target.split(':', 1)
             if inventory_name in app.config.hoverxref_intersphinx:
                 skip_node = False
+                inventory_name_matched = inventory_name
     else:
         # Using intersphinx via ``sphinx.ext.autodoc`` generates links for docstrings like:
         # :py:class:`float`
@@ -226,11 +228,12 @@ def missing_reference(app, env, node, contnode):
                 # The object **does** exist on the inventories defined by the
                 # user: enable hoverxref on this node
                 skip_node = False
+                inventory_name_matched = inventory_name
                 break
 
     newnode = sphinx_missing_reference(app, env, node, contnode)
     if newnode is not None and not skip_node:
-        hoverxref_type = app.config.hoverxref_intersphinx_type or app.config.hoverxref_default_type
+        hoverxref_type = app.config.hoverxref_intersphinx_types.get(inventory_name_matched) or app.config.hoverxref_default_type
         classes = newnode.get('classes')
         classes.extend(['hoverxref', hoverxref_type])
         newnode.replace_attr('classes', classes)
@@ -363,7 +366,7 @@ def setup(app):
     app.add_config_value('hoverxref_role_types', {}, 'env')
     app.add_config_value('hoverxref_default_type', 'tooltip', 'env')
     app.add_config_value('hoverxref_intersphinx', [], 'env')
-    app.add_config_value('hoverxref_intersphinx_type', None, 'env')
+    app.add_config_value('hoverxref_intersphinx_types', {}, 'env')
     app.add_config_value('hoverxref_api_host', 'https://readthedocs.org', 'env')
 
     # Tooltipster settings

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -151,7 +151,7 @@ def setup_intersphinx(app, config):
     https://github.com/sphinx-doc/sphinx/blob/53c1dff/sphinx/ext/intersphinx.py
     """
 
-    hoverxref_intersphinx_enabled = app.config.hoverxref_intersphinx or app.config.hoverxref_auto_ref
+    hoverxref_intersphinx_enabled = (app.config.hoverxref_intersphinx is None and app.config.hoverxref_auto_ref) or app.config.hoverxref_intersphinx
     if not hoverxref_intersphinx_enabled:
         # Do not disconnect original intersphinx missing-reference if the user
         # does not have hoverxref intersphinx enabled
@@ -177,7 +177,7 @@ def missing_reference(app, env, node, contnode):
     We call the original intersphinx extension and add hoverxref CSS classes
     plus the ``data-url`` to the node returned from it.
     """
-    hoverxref_intersphinx_enabled = app.config.hoverxref_intersphinx or app.config.hoverxref_auto_ref
+    hoverxref_intersphinx_enabled = (app.config.hoverxref_intersphinx is None and app.config.hoverxref_auto_ref) or app.config.hoverxref_intersphinx
     if not hoverxref_intersphinx_enabled:
         # Do nothing if the user doesn't have hoverxref intersphinx enabled
         return

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -149,6 +149,8 @@ def setup_intersphinx(app, config):
     disconnect the original listener and add our custom one.
 
     https://github.com/sphinx-doc/sphinx/blob/53c1dff/sphinx/ext/intersphinx.py
+
+    Note that ``hoverxref.extension`` has to be installed **after** ``sphinx.ext.intersphinx``.
     """
     if sphinx.version_info < (3, 0, 0):
         listeners = list(app.events.listeners.get('missing-reference').items())
@@ -171,9 +173,11 @@ def missing_reference(app, env, node, contnode):
     plus the ``data-url`` to the node returned from it.
     """
     newnode = sphinx_missing_reference(app, env, node, contnode)
-    if newnode is not None:
+    intersphinx_enabled = app.config.hoverxref_intersphinx or app.config.hoverxref_auto_ref
+    hoverxref_type = app.config.hoverxref_intersphinx_type or app.config.hoverxref_default_type
+    if newnode is not None and intersphinx_enabled:
         classes = newnode.get('classes')
-        classes.extend(['hoverxref', 'modal'])
+        classes.extend(['hoverxref', hoverxref_type])
         newnode.replace_attr('classes', classes)
         newnode._hoverxref = {
             'data-url': newnode.get('refuri'),
@@ -297,6 +301,8 @@ def setup(app):
     app.add_config_value('hoverxref_ignore_refs', ['genindex', 'modindex', 'search'], 'env')
     app.add_config_value('hoverxref_role_types', {}, 'env')
     app.add_config_value('hoverxref_default_type', 'tooltip', 'env')
+    app.add_config_value('hoverxref_intersphinx', False, 'env')
+    app.add_config_value('hoverxref_intersphinx_type', None, 'env')
     app.add_config_value('hoverxref_api_host', 'https://readthedocs.org', 'env')
 
     # Tooltipster settings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,13 @@ import os
 import shutil
 import pytest
 
-from .utils import srcdir, prefixdocumentsrcdir, customobjectsrcdir, pythondomainsrcdir
+from .utils import srcdir, prefixdocumentsrcdir, customobjectsrcdir, pythondomainsrcdir, intersphinxsrc
 
 
 @pytest.fixture(autouse=True, scope='function')
 def remove_sphinx_build_output():
     """Remove _build/ folder, if exist."""
-    for path in (srcdir, prefixdocumentsrcdir, customobjectsrcdir, pythondomainsrcdir):
+    for path in (srcdir, prefixdocumentsrcdir, customobjectsrcdir, pythondomainsrcdir, intersphinxsrc):
         build_path = os.path.join(path, '_build')
         if os.path.exists(build_path):
             shutil.rmtree(build_path)

--- a/tests/examples/intersphinx/conf.py
+++ b/tests/examples/intersphinx/conf.py
@@ -12,4 +12,4 @@ autosectionlabel_prefix_document = True
 
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
-intersphinx_cache_limit = -1
+intersphinx_cache_limit = 0

--- a/tests/examples/intersphinx/conf.py
+++ b/tests/examples/intersphinx/conf.py
@@ -7,6 +7,9 @@ extensions = [
     'sphinx.ext.autodoc',
 ]
 
+hoverxref_project = 'myproject'
+hoverxref_version = 'myversion'
+
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),

--- a/tests/examples/intersphinx/conf.py
+++ b/tests/examples/intersphinx/conf.py
@@ -4,13 +4,8 @@ master_doc = 'index'
 extensions = [
     'hoverxref.extension',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.autodoc',
 ]
-
-hoverxref_intersphinx = [
-    'python',
-]
-hoverxref_intersphinx_type = 'modal'
-autosectionlabel_prefix_document = True
 
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 intersphinx_mapping = {

--- a/tests/examples/intersphinx/conf.py
+++ b/tests/examples/intersphinx/conf.py
@@ -6,10 +6,15 @@ extensions = [
     'sphinx.ext.intersphinx',
 ]
 
-hoverxref_intersphinx = True
+hoverxref_intersphinx = [
+    'python',
+]
 hoverxref_intersphinx_type = 'modal'
 autosectionlabel_prefix_document = True
 
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'readthedocs': ('https://docs.readthedocs.io/en/stable/', None),
+}
 intersphinx_cache_limit = 0

--- a/tests/examples/intersphinx/conf.py
+++ b/tests/examples/intersphinx/conf.py
@@ -2,8 +2,8 @@
 
 master_doc = 'index'
 extensions = [
+    'hoverxref.extension',
     'sphinx.ext.intersphinx',
-    'hoverxref.extension',  # NOTE: this order is important
 ]
 
 hoverxref_intersphinx = True

--- a/tests/examples/intersphinx/conf.py
+++ b/tests/examples/intersphinx/conf.py
@@ -1,0 +1,13 @@
+# conf.py to run tests
+
+master_doc = 'index'
+extensions = [
+    'hoverxref.extension',
+    'sphinx.ext.intersphinx',
+]
+
+autosectionlabel_prefix_document = True
+
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_cache_limit = -1

--- a/tests/examples/intersphinx/conf.py
+++ b/tests/examples/intersphinx/conf.py
@@ -2,10 +2,12 @@
 
 master_doc = 'index'
 extensions = [
-    'hoverxref.extension',
     'sphinx.ext.intersphinx',
+    'hoverxref.extension',  # NOTE: this order is important
 ]
 
+hoverxref_intersphinx = True
+hoverxref_intersphinx_type = 'modal'
 autosectionlabel_prefix_document = True
 
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html

--- a/tests/examples/intersphinx/index.rst
+++ b/tests/examples/intersphinx/index.rst
@@ -1,0 +1,7 @@
+Example page
+============
+
+This is an example page.
+
+:ref:`This a :ref: to The Python Tutorial using intersphinx <python:tutorial-index>`.
+:ref:`This a :ref: to datetime.datetime Python's function using intersphinx <python:datetime-datetime>`.

--- a/tests/examples/intersphinx/index.rst
+++ b/tests/examples/intersphinx/index.rst
@@ -7,3 +7,10 @@ This is an example page.
 :ref:`This a :ref: to datetime.datetime Python's function using intersphinx <python:datetime-datetime>`.
 
 :ref:`This a :ref: to Config File v2 Read the Docs' page using intersphinx <readthedocs:config-file/v2:python>`.
+
+:py:class:`float`
+
+.. autofunction:: hoverxref.extension.setup
+
+
+:py:func:`hoverxref.extension.setup`

--- a/tests/examples/intersphinx/index.rst
+++ b/tests/examples/intersphinx/index.rst
@@ -5,3 +5,5 @@ This is an example page.
 
 :ref:`This a :ref: to The Python Tutorial using intersphinx <python:tutorial-index>`.
 :ref:`This a :ref: to datetime.datetime Python's function using intersphinx <python:datetime-datetime>`.
+
+:ref:`This a :ref: to Config File v2 Read the Docs' page using intersphinx <readthedocs:config-file/v2:python>`.

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -252,9 +252,9 @@ def test_intersphinx_python_mapping(app, status, warning):
 
     chunks = [
         # Python's links do have hoverxref enabled
-        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>',
-        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>',
-        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/functions.html#float" href="https://docs.python.org/3/library/functions.html#float"><code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code></a>',
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>',
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>',
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/functions.html#float" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.9)"><code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code></a>',
 
         # Read the Docs' link does not have hoverxref enabled
         '<a class="reference external" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" title="(in Read the Docs v5.17.0)"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>',
@@ -288,12 +288,12 @@ def test_intersphinx_all_mappings(app, status, warning):
 
     chunks = [
         # Python's links do have hoverxref enabled
-        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>',
-        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>',
-        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/functions.html#float" href="https://docs.python.org/3/library/functions.html#float"><code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code></a>',
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>',
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>',
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/functions.html#float" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.9)"><code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code></a>',
 
         # Read the Docs' link does have hoverxref enabled
-        '<a class="hoverxref modal reference external" data-url="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>',
+        '<a class="hoverxref modal reference external" data-url="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" title="(in Read the Docs v5.17.0)"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>',
 
         # Python domain's link does have hoverxref enabled
         '<a class="hoverxref tooltip reference internal" data-doc="index" data-docpath="/index.html" data-project="myproject" data-section="hoverxref.extension.setup" data-version="myversion" href="#hoverxref.extension.setup" title="hoverxref.extension.setup"><code class="xref py py-func docutils literal notranslate"><span class="pre">hoverxref.extension.setup()</span></code></a>',

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -214,8 +214,11 @@ def test_intersphinx(app, status, warning):
     content = open(path).read()
 
     chunks = [
-        f'<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>.',
-        f'<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>.</p>',
+        '<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>.',
+        '<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>.</p>',
+        # ``readthedocs`` mapping is not defined for hoverxref intersphinx,
+        # so it only adds the link without the hoverxref classes or data-url attribute
+        '<a class="reference external" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" title="(in Read the Docs v5.17.0)"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>.</p>',
     ]
 
     for chunk in chunks:

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -1,4 +1,5 @@
 import pytest
+import sphinx
 import textwrap
 
 from .utils import srcdir, prefixdocumentsrcdir, customobjectsrcdir, pythondomainsrcdir, intersphinxsrc
@@ -218,9 +219,18 @@ def test_intersphinx_default_configs(app, status, warning):
         '<a class="reference external" href="https://docs.python.org/3/library/datetime.html#datetime-datetime" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>',
         '<a class="reference external" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" title="(in Read the Docs v5.17.0)"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>',
         '<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.9)"><code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code></a>',
-        '<dt id="hoverxref.extension.setup">',
         '<a class="reference internal" href="#hoverxref.extension.setup" title="hoverxref.extension.setup"><code class="xref py py-func docutils literal notranslate"><span class="pre">hoverxref.extension.setup()</span></code></a>',
     ]
+
+    if sphinx.version_info >= (4, 0):
+        chunks.extend([
+            '<dt class="sig sig-object py" id="hoverxref.extension.setup">',
+        ])
+    else:
+        chunks.extend([
+            '<dt id="hoverxref.extension.setup">',
+        ])
+
 
     for chunk in chunks:
         assert chunk in content

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -276,6 +276,9 @@ def test_intersphinx_python_mapping(app, status, warning):
         ],
         'hoverxref_intersphinx_types': {
             'readthedocs': 'modal',
+            'python': {
+                'class': 'modal',
+            }
         },
         'hoverxref_domains': ['py'],
     },
@@ -290,7 +293,7 @@ def test_intersphinx_all_mappings(app, status, warning):
         # Python's links do have hoverxref enabled
         '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>',
         '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>',
-        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/functions.html#float" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.9)"><code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code></a>',
+        '<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/library/functions.html#float" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.9)"><code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code></a>',
 
         # Read the Docs' link does have hoverxref enabled
         '<a class="hoverxref modal reference external" data-url="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" title="(in Read the Docs v5.17.0)"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>',

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -207,18 +207,88 @@ def test_ignore_refs(app, status, warning):
 @pytest.mark.sphinx(
     srcdir=intersphinxsrc,
 )
-def test_intersphinx(app, status, warning):
+def test_intersphinx_default_configs(app, status, warning):
     app.build()
     path = app.outdir / 'index.html'
     assert path.exists() is True
     content = open(path).read()
 
     chunks = [
-        '<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>.',
-        '<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>.</p>',
-        # ``readthedocs`` mapping is not defined for hoverxref intersphinx,
-        # so it only adds the link without the hoverxref classes or data-url attribute
-        '<a class="reference external" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" title="(in Read the Docs v5.17.0)"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>.</p>',
+        '<a class="reference external" href="https://docs.python.org/3/tutorial/index.html#tutorial-index" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>',
+        '<a class="reference external" href="https://docs.python.org/3/library/datetime.html#datetime-datetime" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>',
+        '<a class="reference external" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" title="(in Read the Docs v5.17.0)"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>',
+        '<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.9)"><code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code></a>',
+        '<dt id="hoverxref.extension.setup">',
+        '<a class="reference internal" href="#hoverxref.extension.setup" title="hoverxref.extension.setup"><code class="xref py py-func docutils literal notranslate"><span class="pre">hoverxref.extension.setup()</span></code></a>',
+    ]
+
+    for chunk in chunks:
+        assert chunk in content
+
+
+@pytest.mark.sphinx(
+    srcdir=intersphinxsrc,
+    confoverrides={
+        'hoverxref_intersphinx': [
+            'python',
+        ],
+    },
+)
+def test_intersphinx_python_mapping(app, status, warning):
+    app.build()
+    path = app.outdir / 'index.html'
+    assert path.exists() is True
+    content = open(path).read()
+
+    chunks = [
+        # Python's links do have hoverxref enabled
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>',
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>',
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/functions.html#float" href="https://docs.python.org/3/library/functions.html#float"><code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code></a>',
+
+        # Read the Docs' link does not have hoverxref enabled
+        '<a class="reference external" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" title="(in Read the Docs v5.17.0)"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>',
+
+        # Python's domain does not have hoverxref enabled
+        '<a class="reference internal" href="#hoverxref.extension.setup" title="hoverxref.extension.setup"><code class="xref py py-func docutils literal notranslate"><span class="pre">hoverxref.extension.setup()</span></code></a>',
+    ]
+
+    for chunk in chunks:
+        assert chunk in content
+
+
+@pytest.mark.sphinx(
+    srcdir=intersphinxsrc,
+    confoverrides={
+        'hoverxref_intersphinx': [
+            'readthedocs',
+            'python',
+        ],
+        'hoverxref_intersphinx_types': {
+            'readthedocs': 'modal',
+        },
+        'hoverxref_domains': ['py'],
+        'hoverxref_project': 'test',
+        'hoverxref_version': 'test',
+    },
+)
+def test_intersphinx_all_mappings(app, status, warning):
+    app.build()
+    path = app.outdir / 'index.html'
+    assert path.exists() is True
+    content = open(path).read()
+
+    chunks = [
+        # Python's links do have hoverxref enabled
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>',
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>',
+        '<a class="hoverxref tooltip reference external" data-url="https://docs.python.org/3/library/functions.html#float" href="https://docs.python.org/3/library/functions.html#float"><code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code></a>',
+
+        # Read the Docs' link does have hoverxref enabled
+        '<a class="hoverxref modal reference external" data-url="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>',
+
+        # Python domain's link does have hoverxref enabled
+        '<a class="hoverxref tooltip reference internal" data-doc="index" data-docpath="/index.html" data-project="test" data-section="hoverxref.extension.setup" data-version="test" href="#hoverxref.extension.setup" title="hoverxref.extension.setup"><code class="xref py py-func docutils literal notranslate"><span class="pre">hoverxref.extension.setup()</span></code></a>',
     ]
 
     for chunk in chunks:

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -268,8 +268,6 @@ def test_intersphinx_python_mapping(app, status, warning):
             'readthedocs': 'modal',
         },
         'hoverxref_domains': ['py'],
-        'hoverxref_project': 'test',
-        'hoverxref_version': 'test',
     },
 )
 def test_intersphinx_all_mappings(app, status, warning):

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -214,8 +214,8 @@ def test_intersphinx(app, status, warning):
     content = open(path).read()
 
     chunks = [
-        '<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>.',
-        '<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>.</p>',
+        f'<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>.',
+        f'<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>.</p>',
     ]
 
     for chunk in chunks:

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -214,8 +214,8 @@ def test_intersphinx(app, status, warning):
     content = open(path).read()
 
     chunks = [
-        f'<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>.',
-        f'<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime" title="(in Python v3.9)"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>.</p>',
+        f'<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/tutorial/index.html#tutorial-index" href="https://docs.python.org/3/tutorial/index.html#tutorial-index"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>.',
+        f'<a class="hoverxref modal reference external" data-url="https://docs.python.org/3/library/datetime.html#datetime-datetime" href="https://docs.python.org/3/library/datetime.html#datetime-datetime"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>.</p>',
     ]
 
     for chunk in chunks:

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -286,7 +286,7 @@ def test_intersphinx_all_mappings(app, status, warning):
         '<a class="hoverxref modal reference external" data-url="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>',
 
         # Python domain's link does have hoverxref enabled
-        '<a class="hoverxref tooltip reference internal" data-doc="index" data-docpath="/index.html" data-project="test" data-section="hoverxref.extension.setup" data-version="test" href="#hoverxref.extension.setup" title="hoverxref.extension.setup"><code class="xref py py-func docutils literal notranslate"><span class="pre">hoverxref.extension.setup()</span></code></a>',
+        '<a class="hoverxref tooltip reference internal" data-doc="index" data-docpath="/index.html" data-project="myproject" data-section="hoverxref.extension.setup" data-version="myversion" href="#hoverxref.extension.setup" title="hoverxref.extension.setup"><code class="xref py py-func docutils literal notranslate"><span class="pre">hoverxref.extension.setup()</span></code></a>',
     ]
 
     for chunk in chunks:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,3 +27,10 @@ pythondomainsrcdir = os.path.join(
     'examples',
     'python-domain',
 )
+
+# srcdir with intersphinx configured
+intersphinxsrc = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'examples',
+    'intersphinx',
+)

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
   sphinx33: sphinx~=3.3.0
   sphinx34: sphinx~=3.4.0
   sphinx35: sphinx~=3.5.0
+  sphinx40: sphinx~=4.0.0
   sphinxlatest: sphinx
 commands = pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
   docs
-  py{36,37,38,39}-sphinx{18,20,21,22,23,24,30,31,32,33,34,latest}
+  py{36,37,38,39}-sphinx{18,20,21,22,23,24,30,31,32,33,34,35,latest}
 
 [testenv]
 deps =
@@ -19,6 +19,7 @@ deps =
   sphinx32: sphinx~=3.2.0
   sphinx33: sphinx~=3.3.0
   sphinx34: sphinx~=3.4.0
+  sphinx35: sphinx~=3.5.0
   sphinxlatest: sphinx
 commands = pytest {posargs}
 


### PR DESCRIPTION
Just an idea of what we can do to support intersphinx in this extension. There are different things to coordinate and decide yet, but I wanted to have something working to see how it could fit.

> **Rendered version** with an example: 
> https://sphinx-hoverxref--86.org.readthedocs.build/en/86/usage.html#tooltip-on-intersphinx-content 

### How it works?

Intersphinx subscribes to `missing-reference` event to use different methods to try to resolve the reference. If it succeed by using one of the intersphinx configurations (from `intersphinx_mapping` config) it returns a `nodes.reference`. As we can't hook into the middle of that function, we disconnect the original function called on `missing-reference` event and we connect a custom one. There we call the original function and add some extra data (CSS classes and `data-url`) into the node.

### Small example

It populates the modal with the content of this page https://docs.readthedocs.io/en/stable/config-file/v2.html#search-ranking

![sphinx-hoverxref-intersphinx](https://user-images.githubusercontent.com/244656/90788735-64487300-e306-11ea-98ee-9243ea37c3b4.gif)

### ToDo

- [x] allow style customization (tooltip or modal)
- [x] config to enable/disable tooltip on intersphinx links
- [x] remove the `title=` HTML property?
- [x] write the tests for this cases
- [x] document how to use it
- [x] add an example into the documentation


Closes #51 
Reference https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
Reference https://github.com/sphinx-doc/sphinx/blob/53c1dff/sphinx/ext/intersphinx.py