### PR TITLE
Add MathJax3 Compatability 

### DIFF
--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -26,13 +26,11 @@ function reRenderTooltip (instance, helper) {
 
 
 function reLoadMathJax(elementId) {
-    console.debug('Typesetting new node');
-
     if (parseInt(MathJax.version[0]) >= 3) {
-        MathJax.typesetPromise([elementId]).then(() => {
-            // the new content is has been typeset
-        });
+        console.debug('Typesetting for Mathjax3)
+        MathJax.typesetPromise([elementId]);
     } else {
+        console.debug('Typesetting for MathJax2)
         MathJax.Hub.Queue((["Typeset", MathJax.Hub, elementId]));
     }
 }

--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -27,10 +27,10 @@ function reRenderTooltip (instance, helper) {
 
 function reLoadMathJax(elementId) {
     if (parseInt(MathJax.version[0]) >= 3) {
-        console.debug('Typesetting for Mathjax3);
-        MathJax.typeset();)
+        console.debug('Typesetting for Mathjax3');
+        MathJax.typeset();
     } else {
-        console.debug('Typesetting for MathJax2);
+        console.debug('Typesetting for MathJax2');
         MathJax.Hub.Queue((["Typeset", MathJax.Hub, elementId]));
     }
 }

--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -27,10 +27,10 @@ function reRenderTooltip (instance, helper) {
 
 function reLoadMathJax(elementId) {
     if (parseInt(MathJax.version[0]) >= 3) {
-        console.debug('Typesetting for Mathjax3)
+        console.debug('Typesetting for Mathjax3);
         MathJax.typeset();)
     } else {
-        console.debug('Typesetting for MathJax2)
+        console.debug('Typesetting for MathJax2);
         MathJax.Hub.Queue((["Typeset", MathJax.Hub, elementId]));
     }
 }

--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -28,7 +28,7 @@ function reRenderTooltip (instance, helper) {
 function reLoadMathJax(elementId) {
     if (parseInt(MathJax.version[0]) >= 3) {
         console.debug('Typesetting for Mathjax3)
-        MathJax.typesetPromise([elementId]);
+        MathJax.typeset();)
     } else {
         console.debug('Typesetting for MathJax2)
         MathJax.Hub.Queue((["Typeset", MathJax.Hub, elementId]));

--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -26,8 +26,15 @@ function reRenderTooltip (instance, helper) {
 
 
 function reLoadMathJax(elementId) {
-    console.debug('Triggering MathJax.Hub.Typeset()');
-    MathJax.Hub.Queue((["Typeset", MathJax.Hub, elementId]));
+    console.debug('Typesetting new node');
+
+    if (parseInt(MathJax.version[0]) >= 3) {
+        MathJax.typesetPromise([elementId]).then(() => {
+            // the new content is has been typeset
+        });
+    } else {
+        MathJax.Hub.Queue((["Typeset", MathJax.Hub, elementId]));
+    }
 }
 
 


### PR DESCRIPTION
I'm surprised it was this simple. I don't think MathJax actually exposes a way in their API to get the current version, so I'm not sure how to make this call conditional.

Closes #85 