### PR TITLE
Update `sphinx-tabs` to its latest version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,7 @@
 sphinx==3.5.4
 sphinx-autoapi==1.7.0
 sphinx-rtd-theme==0.5.2
-
-# Newer versions drop support for Sphinx<2 and
-# Sphinx>2 is not detecting that MathJax is enabled
-# and so not rendering MathJax inside the tooltips
-sphinx-tabs==1.1.13  # pyup: ignore
-
+sphinx-tabs==2.1.0
 sphinx-prompt==1.4.0
 sphinx-version-warning==1.1.2
 sphinx-notfound-page==0.6

--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -44,18 +44,37 @@ function reLoadSphinxTabs() {
             // HACK: please, improve this code to call the content of "tab.js" without creating a script element
 
             // Get the URL from the current generated page since it's not always the same
-            var src = $('script[src$="sphinx_tabs/tabs.js"]')[0].src;
+            var src = $('script[src$="sphinx_tabs/tabs.js"]');
+            if (src.length != 0) {
+                // sphinx-tabs < 2
+                src = src[0].src
+                script = d.createElement('script');
+                script.type = 'text/javascript';
+                script.onload = function(){
+                    // remote script has loaded
+                };
+                script.src = src;
+                d.getElementsByTagName('head')[0].appendChild(script);
 
-            script = d.createElement('script');
-            script.type = 'text/javascript';
-            script.onload = function(){
-                // remote script has loaded
-            };
-            script.src = src;
-            d.getElementsByTagName('head')[0].appendChild(script);
+                // Once the script has been executed, we remove it from the DOM
+                script.parentNode.removeChild(script);
+            }
+            var src = $('script[src$="_static/tabs.js"]');
+            if (src.length != 0) {
+                // sphinx-tabs > 2
+                // Borrowed from
+                // https://github.com/executablebooks/sphinx-tabs/blob/0f3cbbe/sphinx_tabs/static/tabs.js#L8-L17
+                var allTabs = document.querySelectorAll('.sphinx-tabs-tab');
+                var tabLists = document.querySelectorAll('[role="tablist"]');
+                allTabs.forEach(tab => {
+                    tab.addEventListener("click", changeTabs);
+                });
 
-            // Once the script has been executed, we remove it from the DOM
-            script.parentNode.removeChild(script);
+                tabLists.forEach(tabList => {
+                    tabList.addEventListener("keydown", keyTabs);
+                });
+            }
+
         }(document));
     };
 };

--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -44,23 +44,23 @@ function reLoadSphinxTabs() {
             // HACK: please, improve this code to call the content of "tab.js" without creating a script element
 
             // Get the URL from the current generated page since it's not always the same
-            var src = $('script[src$="sphinx_tabs/tabs.js"]');
-            if (src.length != 0) {
+            var older_tabs_src = $('script[src$="sphinx_tabs/tabs.js"]');
+            if (older_tabs_src.length != 0) {
                 // sphinx-tabs < 2
-                src = src[0].src
+                older_tabs_src = older_tabs_src[0].older_tabs_src
                 script = d.createElement('script');
                 script.type = 'text/javascript';
                 script.onload = function(){
                     // remote script has loaded
                 };
-                script.src = src;
+                script.older_tabs_src = older_tabs_src;
                 d.getElementsByTagName('head')[0].appendChild(script);
 
                 // Once the script has been executed, we remove it from the DOM
                 script.parentNode.removeChild(script);
             }
-            var src = $('script[src$="_static/tabs.js"]');
-            if (src.length != 0) {
+            var newer_tabs_src = $('script[src$="_static/tabs.js"]');
+            if (newer_tabs_src.length != 0) {
                 // sphinx-tabs > 2
                 // Borrowed from
                 // https://github.com/executablebooks/sphinx-tabs/blob/0f3cbbe/sphinx_tabs/static/tabs.js#L8-L17


### PR DESCRIPTION
Use two different selectors for sphinx-tabs<2 and >=2:

- `sphinx_tabs/tabs.js`
- `_static/tabs.js`

If the first one is used, the old code that adds a `script` tag is used. If the second one (sphinx-tabs>=2) is found, we call a small chunk of code to enable the tabs.

Closes #104 