### PR TITLE
Docs: mention that Sphinx>=3.5 may not work with dynamic content

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -93,6 +93,15 @@ These actions are usually calling a Javascript function.
 ``hoverxref`` is prepared to support this type of content and currently supports rendering
 `sphinx-tabs`_ and mathjax_.
 
+.. warning::
+
+   Note that Sphinx>3.5 adds `a feature to only include JS/CSS in pages where they are used`_ instead of in all the pages.
+   This `may affect the rendering of tooltips`_ that includes content requiring extra rendering steps.
+   **Make sure you are using Sphinx 3.4.x** if you require rendering this type of content in your tooltips.
+
+   .. _a feature to only include JS/CS in pages where they are used: https://github.com/sphinx-doc/sphinx/pull/8631
+   .. _may affect the rendering of tooltips: https://github.com/sphinx-doc/sphinx/issues/9115
+
 
 Tooltip with ``sphinx-tabs``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Mention that when using Sphinx>=3.5 content with MathJax or sphinx-tabs won't
work due to a new feature included in that release of Sphinx.

Closes #123