### PR TITLE
Use `app.set_html_assets_policy` as `'always'`

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -121,7 +121,7 @@ These actions are usually calling a Javascript function.
 
    Note that Sphinx>3.5 adds `a feature to only include JS/CSS in pages where they are used`_ instead of in all the pages.
    This `may affect the rendering of tooltips`_ that includes content requiring extra rendering steps.
-   **Make sure you are using Sphinx 3.4.x** if you require rendering this type of content in your tooltips.
+   **Make sure you are using Sphinx 3.4.x or >=4.1.x** if you require rendering this type of content in your tooltips.
 
    .. _a feature to only include JS/CSS in pages where they are used: https://github.com/sphinx-doc/sphinx/pull/8631
    .. _may affect the rendering of tooltips: https://github.com/sphinx-doc/sphinx/issues/9115

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -337,6 +337,13 @@ def setup_theme(app, exception):
         )
 
 
+def setup_assets_policy(app, exception):
+    """Tell Sphinx to always include assets in all HTML pages."""
+    if sphinx.version_info >= (4, 1, 0):
+        # https://github.com/sphinx-doc/sphinx/pull/9174
+        app.set_html_assets_policy('always')
+
+
 def deprecated_configs_warning(app, exception):
     """Log warning message if old configs are used."""
     default, rebuild, types = app.config.values.get('hoverxref_tooltip_api_host')
@@ -403,6 +410,7 @@ def setup(app):
     app.connect('config-inited', setup_intersphinx)
     app.connect('config-inited', is_hoverxref_configured)
     app.connect('config-inited', setup_theme)
+    app.connect('config-inited', setup_assets_policy)
     app.connect('build-finished', copy_asset_files)
 
     app.connect('missing-reference', missing_reference)

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -339,7 +339,8 @@ def setup_theme(app, exception):
 
 def setup_assets_policy(app, exception):
     """Tell Sphinx to always include assets in all HTML pages."""
-    if sphinx.version_info >= (4, 1, 0):
+    if hasattr(app, 'set_html_assets_policy'):
+        # ``app.set_html_assets_policy`` was introduced in Sphinx 4.1.0
         # https://github.com/sphinx-doc/sphinx/pull/9174
         app.set_html_assets_policy('always')
 


### PR DESCRIPTION
Tell Sphinx to always include assets in all HTML pages

Closes #119