### PR TITLE
Remove `title=` for intersphinx (external links) with hoverxref

### DIFF
--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -93,6 +93,9 @@ function getEmbedURL(url) {
 
 
 $(document).ready(function() {
+    // remove ``title=`` attribute for intersphinx nodes that have hoverxref enabled
+    $('.hoverxref.external').each(function () { $(this).removeAttr('title') });
+
     $('.hoverxref.tooltip').tooltipster({
         theme: {{ hoverxref_tooltip_theme }},
         interactive: {{ 'true' if hoverxref_tooltip_interactive else 'false' }},

--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -93,7 +93,9 @@ function getEmbedURL(url) {
 
 
 $(document).ready(function() {
-    // remove ``title=`` attribute for intersphinx nodes that have hoverxref enabled
+    // Remove ``title=`` attribute for intersphinx nodes that have hoverxref enabled.
+    // It doesn't make sense the browser shows the default tooltip (browser's built-in)
+    // and immediately after that our tooltip was shown.
     $('.hoverxref.external').each(function () { $(this).removeAttr('title') });
 
     $('.hoverxref.tooltip').tooltipster({


### PR DESCRIPTION
It doesn't make sense the browser shows the default tooltip (browser's built-in)
and immediately after that our tooltip was shown.

This commit removes the `title=` property for all intersphinx links where
hoverxref was enabled.

Closes #133 