### PR TITLE
Send custom HTTP header

### DIFF
--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -93,6 +93,13 @@ function getEmbedURL(url) {
 
 
 $(document).ready(function() {
+    // Define a custom HTTP header to send the requests to the server
+    $.ajaxSetup({
+        beforeSend: function(request) {
+            request.setRequestHeader('X-HoverXRef-Version', '{{ http_hoverxref_version }}');
+        }
+    });
+
     // Remove ``title=`` attribute for intersphinx nodes that have hoverxref enabled.
     // It doesn't make sense the browser shows the default tooltip (browser's built-in)
     // and immediately after that our tooltip was shown.

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -65,6 +65,8 @@ def copy_asset_files(app, exception):
                 # Then, add the values that the user overrides
                 context[attr] = getattr(app.config, attr)
 
+        context['http_hoverxref_version'] = version
+
         # Finally, add some non-hoverxref extra configs
         configs = ['html_theme']
         for attr in configs:

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -3,6 +3,8 @@ import pytest
 import sphinx
 import textwrap
 
+from hoverxref import version
+
 from .utils import srcdir, prefixdocumentsrcdir, customobjectsrcdir, pythondomainsrcdir, intersphinxsrc, bibtexdomainsrcdir
 
 
@@ -55,6 +57,7 @@ def test_js_render(app, status, warning):
         "var sphinxtabs = false",
         "var mathjax = false",
         "var url = getEmbedURL(href);",
+        f"request.setRequestHeader('X-HoverXRef-Version', '{version}');",
     ]
 
     for chunk in chunks:


### PR DESCRIPTION
Send `X-HoverXRef-Version` to know that the EmbedAPI is used by this
extension and what version in particular.

It seems that modifying the `User-Agent` is not allowed and it's not preferable
anyways. Knowing the `User-Agent` together with the sphinx-hoverxref version is
good data to have.

Requires #158 for the tests to pass.