### PR TITLE
Ajax header: send the header on each call instead with .ajaxSetup

### DIFF
--- a/hoverxref/_static/js/hoverxref.js_t
+++ b/hoverxref/_static/js/hoverxref.js_t
@@ -93,13 +93,6 @@ function getEmbedURL(url) {
 
 
 $(document).ready(function() {
-    // Define a custom HTTP header to send the requests to the server
-    $.ajaxSetup({
-        beforeSend: function(request) {
-            request.setRequestHeader('X-HoverXRef-Version', '{{ http_hoverxref_version }}');
-        }
-    });
-
     // Remove ``title=`` attribute for intersphinx nodes that have hoverxref enabled.
     // It doesn't make sense the browser shows the default tooltip (browser's built-in)
     // and immediately after that our tooltip was shown.
@@ -122,14 +115,19 @@ $(document).ready(function() {
             // we set a variable so the data is only loaded once via Ajax, not every time the tooltip opens
             if ($origin.data('loaded') !== true) {
                 var url = getEmbedURL(href);
-                $.get(url, function(data) {
-                    // call the 'content' method to update the content of our tooltip with the returned data.
-                    // note: this content update will trigger an update animation (see the updateAnimation option)
-                    instance.content(data['content']);
+                $.ajax({
+                    url: url,
+                    headers: {'X-HoverXRef-Version': '{{ http_hoverxref_version }}'},
+                }).done(
+                    function (data) {
+                        // call the 'content' method to update the content of our tooltip with the returned data.
+                        // note: this content update will trigger an update animation (see the updateAnimation option)
+                        instance.content(data['content']);
 
-                    // to remember that the data has been loaded
-                    $origin.data('loaded', true);
-                });
+                        // to remember that the data has been loaded
+                        $origin.data('loaded', true);
+                    }
+                );
             }
         },
 
@@ -187,48 +185,53 @@ $(document).ready(function() {
     function showModal(element) {
         var href = element.prop('href');
         var url = getEmbedURL(href);
-        $.get(url, function(data) {
-            var content = $('<div></div>');
-            content.html(data['content']);
+        $.ajax({
+            url: url,
+            headers: {'X-HoverXRef-Version': '{{ http_hoverxref_version }}'},
+        }).done(
+            function (data) {
+                var content = $('<div></div>');
+                content.html(data['content']);
 
-            var h1 = $('h1:first', content);
-            var title = h1.text()
-            if (title) {
-                var link = $('a', h1).attr('href') || '#';
+                var h1 = $('h1:first', content);
+                var title = h1.text()
+                if (title) {
+                    var link = $('a', h1).attr('href') || '#';
 
-                // Remove permalink icon from the title
-                var title = title.replace('¶', '').replace('', '');
+                    // Remove permalink icon from the title
+                    var title = title.replace('¶', '').replace('', '');
 
-                var a = $('<a></a>').attr('href', link).text('{{ hoverxref_modal_prefix_title }}' + title);
-            }
-            else {
-                var a = '{{ hoverxref_modal_prefix_title }}{{ hoverxref_modal_default_title }}';
-            }
-            h1.replaceWith('');
+                    var a = $('<a></a>').attr('href', link).text('{{ hoverxref_modal_prefix_title }}' + title);
+                }
+                else {
+                    var a = '{{ hoverxref_modal_prefix_title }}{{ hoverxref_modal_default_title }}';
+                }
+                h1.replaceWith('');
 
-            $('#micromodal-title').html(a);
-            $('#micromodal-content').html(content);
-            MicroModal.show('micromodal', {
-                {% if sphinx_rtd_theme or hoverxref_modal_onshow_function %}
-                onShow: {{ hoverxref_modal_onshow_function|default('onShow', true) }},
-                {% endif %}
-                openClass: '{{ hoverxref_modal_openclass }}',
-                disableScroll: {{ 'true' if hoverxref_modal_disable_scroll else 'false' }},
-                disableFocus: {{ 'true' if hoverxref_modal_disable_focus else 'false' }},
-                awaitOpenAnimation: {{ 'true' if hoverxref_modal_awaitopenanimation else 'false' }},
-                awaitCloseAnimation: {{ 'true' if hoverxref_modal_awaitcloseanimation else 'false' }},
-                debugMode: {{ 'true' if hoverxref_modal_debugmode else 'false' }}
-            });
-            $('#micromodal .modal__container').scrollTop(0);
-            reLoadSphinxTabs();
-            if (mathjax) {
-                if (typeof MathJax !== 'undefined') {
-                    reLoadMathJax('micromodal');
-                } else {
-                    console.debug('Not triggering MathJax because it is not defined');
+                $('#micromodal-title').html(a);
+                $('#micromodal-content').html(content);
+                MicroModal.show('micromodal', {
+                    {% if sphinx_rtd_theme or hoverxref_modal_onshow_function %}
+                    onShow: {{ hoverxref_modal_onshow_function|default('onShow', true) }},
+                    {% endif %}
+                    openClass: '{{ hoverxref_modal_openclass }}',
+                    disableScroll: {{ 'true' if hoverxref_modal_disable_scroll else 'false' }},
+                    disableFocus: {{ 'true' if hoverxref_modal_disable_focus else 'false' }},
+                    awaitOpenAnimation: {{ 'true' if hoverxref_modal_awaitopenanimation else 'false' }},
+                    awaitCloseAnimation: {{ 'true' if hoverxref_modal_awaitcloseanimation else 'false' }},
+                    debugMode: {{ 'true' if hoverxref_modal_debugmode else 'false' }}
+                });
+                $('#micromodal .modal__container').scrollTop(0);
+                reLoadSphinxTabs();
+                if (mathjax) {
+                    if (typeof MathJax !== 'undefined') {
+                        reLoadMathJax('micromodal');
+                    } else {
+                        console.debug('Not triggering MathJax because it is not defined');
+                    };
                 };
-            };
-        });
+            }
+        );
     };
 
     var delay = {{ hoverxref_modal_hover_delay }}, setTimeoutConst;

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -57,7 +57,7 @@ def test_js_render(app, status, warning):
         "var sphinxtabs = false",
         "var mathjax = false",
         "var url = getEmbedURL(href);",
-        f"request.setRequestHeader('X-HoverXRef-Version', '{version}');",
+        f"headers: {{'X-HoverXRef-Version': '{version}'}}",
     ]
 
     for chunk in chunks:


### PR DESCRIPTION
Since `.ajaxSetup` works globally, it was interfering with other `.ajaxSetup`
being called in other plugins.

Closes #165 