### PR TITLE
Intersphinx: improve robustness

### DIFF
--- a/tests/examples/intersphinx/index.rst
+++ b/tests/examples/intersphinx/index.rst
@@ -14,3 +14,6 @@ This is an example page.
 
 
 :py:func:`hoverxref.extension.setup`
+
+Using just the ``default_role = "obj"`` with intersphinx object: `float`.
+See https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-default_role

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -306,6 +306,7 @@ def test_intersphinx_python_mapping(app, status, warning):
             }
         },
         'hoverxref_domains': ['py'],
+        'default_role': 'obj',
     },
 )
 def test_intersphinx_all_mappings(app, status, warning):
@@ -323,6 +324,9 @@ def test_intersphinx_all_mappings(app, status, warning):
         # Read the Docs' link does have hoverxref enabled
         r'<a class="hoverxref modal reference external" href="https://docs.readthedocs.io/en/stable/config-file/v2.html#python" title="\(in Read the Docs user documentation v\d\d?.\d\d?.\d+\)"><span class="xref std std-ref">This a :ref: to Config File v2 Read the Docs’ page using intersphinx</span></a>',
 
+        # Using `default_role = 'obj'`
+        # Note the difference with the same `float` line previouly. Here it uses `py-obj` instead of `py-class`.
+        '<a class="hoverxref tooltip reference external" href="https://docs.python.org/3/library/functions.html#float" title="\(in Python v3.\d\d?\)"><code class="xref py py-obj docutils literal notranslate"><span class="pre">float</span></code></a>'
     ]
 
     chunks = [


### PR DESCRIPTION
We were generating the inventory's key manually based on the `reftype` and
fallbacks. However, we weren't covering all the possible cases. This commit,
uses `.objtypes_for_role` domain's method to get all the possible names for a
particular `reftype` on a domain.

With this change, it also adds supports for generic `obj` type in a domain,
making our code to find all the possible alternative keys in that particular
domain. This is useful when using `default_role = 'obj'` as requested in
https://github.com/readthedocs/sphinx-hoverxref/issues/170

Closes #170 