### PR TITLE
Test: update testing versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,26 +8,13 @@ commands:
         type: string
       sphinx-version:
         type: string
-        default: "18,20,21,22,23,24,30,31,32,33,34,35,40,41,42,43,latest"
+        default: "18,20,21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,45,50,latest"
     steps:
       - checkout
       - run: pip install --user tox
       - run: tox -e "<<parameters.version>>-sphinx{<<parameters.sphinx-version>>}"
 
 jobs:
-  py36:
-    docker:
-      - image: 'cimg/python:3.6'
-    steps:
-      - run-tox:
-          version: py36
-  py37:
-    docker:
-      - image: 'cimg/python:3.7'
-    steps:
-      - run-tox:
-          version: py37
-
   py38:
     docker:
       - image: 'cimg/python:3.8'
@@ -50,14 +37,12 @@ jobs:
           version: py310
           # Do not run tests for Python 3.10 and some versions of Sphinx because it's broken
           # See https://github.com/sphinx-doc/sphinx/issues/9816
-          sphinx-version: "18,20,21,22,23,24,42,43,latest"
+          sphinx-version: "18,20,21,22,23,24,42,43,44,45,50,latest"
 
 workflows:
   version: 2
   test:
     jobs:
-      - py36
-      - py37
       - py38
       - py39
       - py310

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
   docs
-  py{36,37,38,39}-sphinx{18,20,21,22,23,24,30,31,32,33,34,35,40,41,42,43,latest}
-  py{310}-sphinx{18,20,21,22,23,24,42,43,latest}
+  py{38,39}-sphinx{18,20,21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,45,50,latest}
+  py{310}-sphinx{18,20,21,22,23,24,42,43,44,45,50,latest}
 
 [testenv]
 deps =
@@ -26,6 +26,9 @@ deps =
   sphinx41: sphinx~=4.1.0
   sphinx42: sphinx~=4.2.0
   sphinx43: sphinx~=4.3.0
+  sphinx44: sphinx~=4.4.0
+  sphinx45: sphinx~=4.5.0
+  sphinx50: sphinx~=5.0.0
   sphinxlatest: sphinx
 
 commands = pytest {posargs}
@@ -33,12 +36,16 @@ commands = pytest {posargs}
 # Pin docutils<0.18 for all Python versions using Sphinx 1.x, 2.x, 3.x, 4.0, 4.1
 # since it's incompatible and generating lot of errors
 # https://tox.wiki/en/latest/config.html#generating-environments-conditional-settings
-[testenv:py{36,37,38,39,310}-sphinx{18,20,21,22,23,24,30,31,32,33,34,35,40,41}]
+#
+# Pin jinja2<3.1.0 because there is an incompatibility with the newer version:
+# ImportError: cannot import name 'contextfunction' from 'jinja2'
+[testenv:py{38,39,310}-sphinx{18,20,21,22,23,24,30,31,32,33,34,35,40,41}]
 deps =
   {[testenv]deps}
   docutils<0.18
+  jinja2<3.1.0
 
-[testenv:py310-sphinx43]
+[testenv:py310-sphinx50]
 deps =
   {[testenv]deps}
   pytest-cov


### PR DESCRIPTION
- remove Python 3.6 and 3.7
- add Sphinx versions 4.4, 4.5 and 5.0
- pin Jinja2 to <3.0.3 for older Sphinx versions