### PR TITLE
Packaging: be more friendly with package maintainers

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,8 +14,8 @@
 #
 import os
 import datetime
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
We don't really need this change for sphinx-hoverxref itself, but it seems this
helps package maintainers when building and packaging this extension.

Closes #178