### PR TITLE
Style: reduce h1 font on tooltip content when using furo theme

### DIFF
--- a/hoverxref/_static/css/furo.css
+++ b/hoverxref/_static/css/furo.css
@@ -1,0 +1,11 @@
+.tooltipster-sidetip.tooltipster-shadow.tooltipster-shadow-custom .tooltipster-content h1 {
+    font-size: 2em;
+}
+
+.tooltipster-sidetip.tooltipster-shadow.tooltipster-shadow-custom .tooltipster-content h2 {
+    font-size: 1.7em;
+}
+
+.tooltipster-sidetip.tooltipster-shadow.tooltipster-shadow-custom .tooltipster-content h3 {
+    font-size: 1.4em;
+}

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -285,6 +285,9 @@ def setup_theme(app, exception):
     elif theme == 'sphinx_rtd_theme':
         if app.config.hoverxref_modal_class == default:
             css_file = 'css/sphinx_rtd_theme.css'
+    elif theme == 'furo':
+        if app.config.hoverxref_modal_class == default:
+            css_file = 'css/furo.css'
 
     if css_file:
         app.add_css_file(css_file)


### PR DESCRIPTION
I just forced,

* `font-size: 2em` for `h1`
* `font-size: 1.7em` for `h2`
* `font-size: 1.4em` for `h3`

I did a quick QA locally and it seems it looks fine. I'm sure there are better
improvements that can be done here, but at least it doesn't look breaking at
first sight.

Closes #188 