### PR TITLE
Docs: readme and release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Or, alternatively, install it from GitHub directly (requires git):
 
 ::
 
-   pip install git+https://github.com/readthedocs/sphinx-hoverxref@master
+   pip install git+https://github.com/readthedocs/sphinx-hoverxref
 
 
 Configuration

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -9,9 +9,13 @@ These are the steps needed to release a new version:
      $ pip install flit bumpver
 
 #. Update the ``CHANGELOG.rst`` with the changes included in this release
+#. Add ``CHANGELOG.rst`` to git stage::
+
+     $ git add CHANGELOG.rst
+
 #. Increase version (``--patch``, ``--minor`` or ``--major``)::
 
-     $ bumpver update --minor
+     $ bumpver update --minor --allow-dirty
 
 #. Build the package and check everything is correct::
 


### PR DESCRIPTION
- readme still pointed to `master` :(
- add the `CHANGELOG.rst` to the git stage
- we need `--allow-dirty` because we are modifying the `CHANGELOG.rst` in the
  same commit