### PR TITLE
Intersphinx and Python domain

### DIFF
--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -197,7 +197,7 @@ def missing_reference(app, env, node, contnode):
 
     See https://github.com/sphinx-doc/sphinx/blob/4d90277c/sphinx/ext/intersphinx.py#L244-L250
     """
-    if not app.config.hoverxref_intersphinx:
+    if not app.config.hoverxref_intersphinx or 'sphinx.ext.intersphinx' not in app.config.extensions:
         # Do nothing if the user doesn't have hoverxref intersphinx enabled
         return
 
@@ -239,7 +239,13 @@ def missing_reference(app, env, node, contnode):
             inventory = inventories.named_inventory.get(inventory_name, {})
             # Logic of `.objtypes_for_role` stolen from
             # https://github.com/sphinx-doc/sphinx/blob/b8789b4c/sphinx/ext/intersphinx.py#L397
-            for objtype in env.get_domain(domain).objtypes_for_role(reftype):
+            objtypes_for_role = env.get_domain(domain).objtypes_for_role(reftype)
+
+            # If the reftype is not defined on the domain, we skip it
+            if not objtypes_for_role:
+                continue
+
+            for objtype in objtypes_for_role:
                 inventory_member = inventory.get(f'{domain}:{objtype}')
 
                 if inventory_member and inventory_member.get(target) is not None:

--- a/tests/examples/python-domain/index.rst
+++ b/tests/examples/python-domain/index.rst
@@ -8,3 +8,6 @@ This is an example page with a Python Domain role usage.
 :py:mod:`hoverxref.extension`
 
 :py:func:`hoverxref.extension.setup`
+
+Note that ``:py:const:`` does not exist in the Python domain, but it shouldn't make the build to fail.
+"Constant" should be rendered in the same way as the other Python objects: :py:const:`Constant`

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -118,6 +118,38 @@ def test_python_domain(app, status, warning):
         '<a class="hoverxref tooltip reference internal" href="api.html#hoverxref.extension.HoverXRefStandardDomainMixin" title="hoverxref.extension.HoverXRefStandardDomainMixin"><code class="xref py py-class docutils literal notranslate"><span class="pre">This</span> <span class="pre">is</span> <span class="pre">a</span> <span class="pre">:py:class:</span> <span class="pre">role</span> <span class="pre">to</span> <span class="pre">a</span> <span class="pre">Python</span> <span class="pre">object</span></code></a>',
         '<a class="hoverxref tooltip reference internal" href="api.html#module-hoverxref.extension" title="hoverxref.extension"><code class="xref py py-mod docutils literal notranslate"><span class="pre">hoverxref.extension</span></code></a>',
         '<a class="hoverxref tooltip reference internal" href="api.html#hoverxref.extension.setup" title="hoverxref.extension.setup"><code class="xref py py-func docutils literal notranslate"><span class="pre">hoverxref.extension.setup()</span></code></a>',
+        '<code class="xref py py-const docutils literal notranslate"><span class="pre">Constant</span></code>',
+    ]
+
+    for chunk in chunks:
+        assert chunk in content
+
+
+@pytest.mark.sphinx(
+    srcdir=pythondomainsrcdir,
+    confoverrides={
+        'hoverxref_domains': ['py'],
+        'hoverxref_intersphinx': ['python'],
+        'hoverxref_auto_ref': True,
+        'extensions': [
+            'sphinx.ext.autodoc',
+            'sphinx.ext.autosectionlabel',
+            'sphinx.ext.intersphinx',
+            'hoverxref.extension',
+        ],
+    },
+)
+def test_python_domain_intersphinx(app, status, warning):
+    app.build()
+    path = app.outdir / 'index.html'
+    assert path.exists() is True
+    content = open(path).read()
+
+    chunks = [
+        '<a class="hoverxref tooltip reference internal" href="api.html#hoverxref.extension.HoverXRefStandardDomainMixin" title="hoverxref.extension.HoverXRefStandardDomainMixin"><code class="xref py py-class docutils literal notranslate"><span class="pre">This</span> <span class="pre">is</span> <span class="pre">a</span> <span class="pre">:py:class:</span> <span class="pre">role</span> <span class="pre">to</span> <span class="pre">a</span> <span class="pre">Python</span> <span class="pre">object</span></code></a>',
+        '<a class="hoverxref tooltip reference internal" href="api.html#module-hoverxref.extension" title="hoverxref.extension"><code class="xref py py-mod docutils literal notranslate"><span class="pre">hoverxref.extension</span></code></a>',
+        '<a class="hoverxref tooltip reference internal" href="api.html#hoverxref.extension.setup" title="hoverxref.extension.setup"><code class="xref py py-func docutils literal notranslate"><span class="pre">hoverxref.extension.setup()</span></code></a>',
+        '<code class="xref py py-const docutils literal notranslate"><span class="pre">Constant</span></code>',
     ]
 
     for chunk in chunks:


### PR DESCRIPTION
Skip the node in case the `reftype` is not defined for the particular domain we
are checking for.

Closes #192