### PR TITLE
jQuery: inject the CDN version if Sphinx>=6.x

### DIFF
--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -318,6 +318,27 @@ def deprecated_configs_warning(app, exception):
         app.config.hoverxref_api_host = app.config.hoverxref_tooltip_api_host
 
 
+def setup_jquery(app, exception):
+    """
+    Inject jQuery if Sphinx>=6.x
+
+    Staring on Sphinx 6.0, jQuery is not included with it anymore.
+    As this extension depends on jQuery, we are including it when Sphinx>=6.x
+    """
+
+    if sphinx.version_info >= (6, 0, 0):
+        # https://jquery.com/download/#using-jquery-with-a-cdn
+        jquery_cdn_url = "https://code.jquery.com/jquery-3.6.0.min.js"
+        html_js_files = getattr(app.config, "html_js_files", [])
+        html_js_files.append((
+            jquery_cdn_url,
+            {
+                'integrity': 'sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=',
+                'crossorigin': 'anonymous'
+            }
+        ))
+        app.config.html_js_files = html_js_files
+
 
 def setup(app):
     """Setup ``hoverxref`` Sphinx extension."""
@@ -364,6 +385,7 @@ def setup(app):
     app.add_config_value('hoverxref_modal_prefix_title', '📝 ', 'env')
 
     app.connect('config-inited', deprecated_configs_warning)
+    app.connect('config-inited', setup_jquery)
 
     app.connect('config-inited', setup_domains)
     app.connect('config-inited', setup_sphinx_tabs)

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -371,3 +371,21 @@ def test_intersphinx_all_mappings(app, status, warning):
 
     for chunk in chunks_regex:
         assert re.search(chunk, content)
+
+
+@pytest.mark.sphinx(
+    srcdir=srcdir,
+)
+def test_jquery_cdn_injection(app, status, warning):
+    """The extension should not change the output if not configured."""
+    app.build()
+    path = app.outdir / 'index.html'
+    assert path.exists() is True
+    content = open(path).read()
+
+    chunk = '<script crossorigin="anonymous" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" src="https://code.jquery.com/jquery-3.6.0.min.js"></script>'
+
+    if sphinx.version_info >= (6, 0, 0):
+        assert chunk in content
+    else:
+        assert chunk not in content


### PR DESCRIPTION
Sphinx>=6.x will remove jQuery framework. As this extension depends on jQuery, we will include it by ourselves.

Closes #160 