### PR TITLE
Docs: update requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,15 +6,15 @@
 #
 alabaster==0.7.12
     # via sphinx
-astroid==2.11.5
+astroid==2.12.2
     # via sphinx-autoapi
-babel==2.10.1
+babel==2.10.3
     # via sphinx
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
-colorama==0.4.4
+colorama==0.4.5
     # via sphinx-autobuild
 docutils==0.17.1
     # via
@@ -25,7 +25,7 @@ docutils==0.17.1
     #   sphinxcontrib-bibtex
 idna==3.3
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
 jinja2==3.1.2
     # via
@@ -60,7 +60,7 @@ pyyaml==6.0
     # via
     #   pybtex
     #   sphinx-autoapi
-requests==2.27.1
+requests==2.28.1
     # via sphinx
 six==1.16.0
     # via
@@ -107,14 +107,11 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-tornado==6.1
+tornado==6.2
     # via livereload
 unidecode==1.3.4
     # via sphinx-autoapi
-urllib3==1.26.9
+urllib3==1.26.10
     # via requests
 wrapt==1.14.1
     # via astroid
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ doc = [
     "sphinx",
     "sphinx-autoapi",
     "sphinx-rtd-theme",
-    "sphinx-tabs",
+    "sphinx-tabs==3.3.1",
     "sphinx-prompt",
     "sphinx-version-warning",
     "sphinx-notfound-page",


### PR DESCRIPTION
I had to pin sphinx-tabs because the newer version is incompatible with
sphinx-rtd-theme, due to docutils<0.18