### PR TITLE
Intersphinx: ignore nodes without domain

### DIFF
--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -235,7 +235,11 @@ def missing_reference(app, env, node, contnode):
             if inventory_name in app.config.hoverxref_intersphinx:
                 skip_node = False
                 inventory_name_matched = inventory_name
-    else:
+
+    # Skip this node completely if the domain is empty (`None` or `''`).
+    # I found this happens in weird scenarios.
+    # I'm considering this an edge case and ignore it for now.
+    elif domain:
         # Using intersphinx via ``sphinx.ext.autodoc`` generates links for docstrings like:
         # :py:class:`float`
         # and the node will have these attribues:


### PR DESCRIPTION
While using `setuptools` documentation project as example I found this error
case. I'm not sure why it's happening, but I'm considering it an edge case for
now and ignoring these nodes

Node content:

```
{'rawsource': '`the PyPA
Specification\n<PyPUG:specifications/declaring-project-metadata>`', 'children':
[<literal: <#text: 'the PyPA Speci ...'>>], 'attributes': {'ids': [], 'classes':
[], 'names': [], 'dupnames': [], 'backrefs': [], 'refdoc': 'history',
'refdomain': '', 'reftype': 'any', 'refexplicit': True, 'refwarn': True,
'reftarget': 'PyPUG:specifications/declaring-project-metadata'}, 'tagname':
'pending_xref', 'source': '../CHANGES (links).rst', 'line': 328, 'parent':
<paragraph: <#text: 'Please note th ...'><literal...><#text: ' file  ...>}
```

Full traceback:

```
Traceback (most recent call last):
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/cmd/build.py", line 276, in build_main
    app.build(args.force_all, filenames)
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/application.py", line 329, in build
    self.builder.build_update()
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 290, in build_update
    len(to_build))
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 352, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 544, in write
    self._write_serial(sorted(docnames))
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 551, in _write_serial
    doctree = self.env.get_and_resolve_doctree(docname, self)
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/environment/__init__.py", line 530, in get_and_resolve_doctree
    self.apply_post_transforms(doctree, docname)
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/environment/__init__.py", line 576, in apply_post_transforms
    transformer.apply_transforms()
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/transforms/__init__.py", line 80, in apply_transforms
    super().apply_transforms()
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/docutils/transforms/__init__.py", line 171, in apply_transforms
    transform.apply(**kwargs)
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/transforms/post_transforms/__init__.py", line 35, in apply
    self.run(**kwargs)
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/transforms/post_transforms/__init__.py", line 93, in run
    allowed_exceptions=(NoUri,))
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/application.py", line 458, in emit_firstresult
    allowed_exceptions=allowed_exceptions)
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/events.py", line 112, in emit_firstresult
    for result in self.emit(name, *args, allowed_exceptions=allowed_exceptions):
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/events.py", line 94, in emit
    results.append(listener.handler(self.app, *args))
  File "/home/humitos/rtfd/code/sphinx-hoverxref/hoverxref/extension.py", line 252, in missing_reference
    objtypes_for_role = env.get_domain(domain).objtypes_for_role(reftype)
  File "/home/humitos/rtfd/repos/setuptools/.direnv/python-3.7.13/lib/python3.7/site-packages/sphinx/environment/__init__.py", line 507, in get_domain
    raise ExtensionError(__('Domain %r is not registered') % domainname) from exc
sphinx.errors.ExtensionError: Domain '' is not registered
```