### PR TITLE
Handle explicit intersphinx inventory names in all domains

### DIFF
--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -222,19 +222,18 @@ def missing_reference(app, env, node, contnode):
     skip_node = True
     inventory_name_matched = None
 
-    if domain == 'std':
-        # Using ``:ref:`` manually, we could write intersphinx like:
+    if ':' in target:
+        # Using intersphinx with an explicit inventory name like:
         # :ref:`datetime <python:datetime.datetime>`
         # and the node will have these attribues:
         #   refdomain: std
         #   reftype: ref
         #   reftarget: python:datetime.datetime
         #   refexplicit: True
-        if ':' in target:
-            inventory_name, _ = target.split(':', 1)
-            if inventory_name in app.config.hoverxref_intersphinx:
-                skip_node = False
-                inventory_name_matched = inventory_name
+        inventory_name, _ = target.split(':', 1)
+        if inventory_name in app.config.hoverxref_intersphinx:
+            skip_node = False
+            inventory_name_matched = inventory_name
 
     # Skip this node completely if the domain is empty (`None` or `''`).
     # I found this happens in weird scenarios.

--- a/tests/examples/intersphinx/index.rst
+++ b/tests/examples/intersphinx/index.rst
@@ -5,6 +5,7 @@ This is an example page.
 
 :ref:`This a :ref: to The Python Tutorial using intersphinx <python:tutorial-index>`.
 :ref:`This a :ref: to datetime.datetime Python's function using intersphinx <python:datetime-datetime>`.
+:py:attr:`Python's datetime.time.minute <python:datetime.time.minute>`.
 
 :ref:`This a :ref: to Config File v2 Read the Docs' page using intersphinx <readthedocs:config-file/v2:python>`.
 

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -351,6 +351,7 @@ def test_intersphinx_all_mappings(app, status, warning):
         # Python's links do have hoverxref enabled
         r'<a class="hxr-hoverxref hxr-tooltip reference external" href="https://docs.python.org/3/tutorial/index.html#tutorial-index" title="\(in Python v3.\d\d?\)"><span class="xref std std-ref">This a :ref: to The Python Tutorial using intersphinx</span></a>',
         r'<a class="hxr-hoverxref hxr-tooltip reference external" href="https://docs.python.org/3/library/datetime.html#datetime-datetime" title="\(in Python v3.\d\d?\)"><span class="xref std std-ref">This a :ref: to datetime.datetime Python’s function using intersphinx</span></a>',
+        r'<a class="hxr-hoverxref hxr-tooltip reference external" href="https://docs.python.org/3/library/datetime.html#datetime.time.minute" title="\(in Python v3.\d\d?\)"><code class="xref py py-attr docutils literal notranslate"><span class="pre">Python\'s</span> <span class="pre">datetime.time.minute</span></code></a>',
         r'<a class="hxr-hoverxref hxr-modal reference external" href="https://docs.python.org/3/library/functions.html#float" title="\(in Python v3.\d\d?\)"><code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code></a>',
 
         # Read the Docs' link does have hoverxref enabled


### PR DESCRIPTION
Intersphinx supports explicitly specifying the inventory name in a link target, e.g. the `python:` part in ``:ref:`python:datetime-datetime` ``.

The custom `missing_reference` hook in hoverxref handles such target names as well, but only in the `std` domain (as far as I can tell, particularly for `:ref:`, which is in the `std` domain).

Intersphinx supports target names with explicit inventories regardless of role/domain, which means ``:py:attr:`python:datetime.time.minute` `` results in the correct link, but without the hoverxref popup as the `python:` prefix isn't handled by hoverxref in this case.

---
This PR attempts to fix this by removing the check for the `std` domain, which I believe intersphinx also [doesn't check](https://github.com/sphinx-doc/sphinx/blob/4d90277c/sphinx/ext/intersphinx.py#L295-L300).

I'm very much not sure if this makes sense with how Sphinx, Intersphinx and sphinx-hoverxref interact, or if there are side-effects, I don't know a whole lot about Sphinx internals :sweat_smile: Nevertheless, this fixes the aforementioned issue, and tests pass fine :)

The difference between sphinx-hoverxref 1.2.0 and this PR can be seen here:
- https://sphinx-test-stuff.readthedocs.io/en/hoverxref-intersphinx/
- https://sphinx-test-stuff.readthedocs.io/en/hoverxref-intersphinx-fixed/

Note the difference on the second `:attr:` link, while hovering over the second `:ref:` link works in both versions.

<!-- readthedocs-preview sphinx-hoverxref start -->
----
:books: Documentation preview :books:: https://sphinx-hoverxref--236.org.readthedocs.build/en/236/

<!-- readthedocs-preview sphinx-hoverxref end -->

<!-- readthedocs-preview read-the-docs-sphinx-hoverxref start -->
----
:books: Documentation preview :books:: https://read-the-docs-sphinx-hoverxref--236.com.readthedocs.build/en/236/

<!-- readthedocs-preview read-the-docs-sphinx-hoverxref end -->