### PR TITLE
Make usage of `sphinxcontrib-jquery`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -103,6 +103,8 @@ sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
+sphinxcontrib-jquery==2.0.0
+    # via sphinx-hoverxref (pyproject.toml)
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
@@ -119,3 +121,6 @@ urllib3==1.26.12
     # via requests
 wrapt==1.14.1
     # via astroid
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -397,6 +397,9 @@ def setup(app):
         if f.endswith('.css') or f.endswith('.css_t'):
             app.add_css_file(f.replace('.css_t', '.css'))
 
+    # Sphinx>=6 won't include jQuery anymore
+    app.setup_extension('sphinxcontrib.jquery')
+
     return {
         'version': __version__,
         'parallel_read_safe': True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ keywords=[
 ]
 dependencies = [
     "sphinx >=1.8",
+    "sphinxcontrib-jquery",
 ]
 version = "1.2.0"
 readme = "README.rst"


### PR DESCRIPTION
Sphinx 6.x is removing jQuery. So, we need to manually add it.

Closes #160 
Based on https://github.com/readthedocs/readthedocs.org/pull/9665/

<!-- readthedocs-preview sphinx-hoverxref start -->
----
:books: Documentation preview :books:: https://sphinx-hoverxref--241.org.readthedocs.build/en/241/

<!-- readthedocs-preview sphinx-hoverxref end -->

<!-- readthedocs-preview read-the-docs-sphinx-hoverxref start -->
----
:books: Documentation preview :books:: https://read-the-docs-sphinx-hoverxref--241.com.readthedocs.build/en/241/

<!-- readthedocs-preview read-the-docs-sphinx-hoverxref end -->