### PR TITLE
Requirements: unpin sphinx-tabs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ doc = [
     "sphinx",
     "sphinx-autoapi",
     "sphinx-rtd-theme",
-    "sphinx-tabs==3.3.1",
+    "sphinx-tabs",
     "sphinx-prompt",
     "sphinx-version-warning",
     "sphinx-notfound-page",


### PR DESCRIPTION
This should install the proper version of `docutils` without finding any incompatibility.