### PR TITLE
Experiment: Is docs page on "Usage" borked because of missing jquery?

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     'versionwarning.extension',
     'notfound.extension',
     'sphinxcontrib.bibtex',
+    'sphinxcontrib.jquery',
     'sphinxemoji.sphinxemoji',
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ extensions = [
     'hoverxref.extension',
     'versionwarning.extension',
     'notfound.extension',
-    'sphinxcontrib.bibtex',
+#    'sphinxcontrib.bibtex',
     'sphinxcontrib.jquery',
     'sphinxemoji.sphinxemoji',
 ]


### PR DESCRIPTION
Currently, https://sphinx-hoverxref.readthedocs.io/en/latest/usage.html rendering is broken at the end of the page.

There are a few script errors, but I couldn't tell if it is because jQuery is loaded too late. It is finally loaded, though (`$` is defined etc).

![image](https://user-images.githubusercontent.com/374612/232517720-2da3f7db-c4bd-4877-9e02-5f6a22293df2.png)


<!-- readthedocs-preview read-the-docs-sphinx-hoverxref start -->
----
:books: Documentation preview :books:: https://read-the-docs-sphinx-hoverxref--259.com.readthedocs.build/en/259/

<!-- readthedocs-preview read-the-docs-sphinx-hoverxref end -->