### PR TITLE
Remove RTD .com preview from pr-preview-links.yaml

### DIFF
--- a/.github/workflows/pr-preview-links.yaml
+++ b/.github/workflows/pr-preview-links.yaml
@@ -14,11 +14,3 @@ jobs:
       - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "sphinx-hoverxref"
-
-  pr-preview-links-business:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: readthedocs/actions/preview@v1
-        with:
-          project-slug: "read-the-docs-sphinx-hoverxref"
-          platform: "business"


### PR DESCRIPTION
The .com link is invalid? There are no builds there.

I also noticed a case of "race condition" in the editing which illustrates how we need to change the Action's URL feedback as a comment, rather than editing the PR description.

In one PR, only the .com link was present:

![image](https://github.com/readthedocs/sphinx-hoverxref/assets/374612/d0f65649-2a7f-4175-a5b8-4fa4e7839d37)

![image](https://github.com/readthedocs/sphinx-hoverxref/assets/374612/53fb806f-0e7e-4c74-9506-0e42cb03dd50)

But looking around at other PRs, both links usually show up.

<!-- readthedocs-preview sphinx-hoverxref start -->
----
:books: Documentation preview :books:: https://sphinx-hoverxref--262.org.readthedocs.build/en/262/

<!-- readthedocs-preview sphinx-hoverxref end -->

<!-- readthedocs-preview read-the-docs-sphinx-hoverxref start -->
----
:books: Documentation preview :books:: https://read-the-docs-sphinx-hoverxref--262.com.readthedocs.build/en/262/

<!-- readthedocs-preview read-the-docs-sphinx-hoverxref end -->