### PR TITLE
Dependencies: add minimum docutils version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile --extra=doc --output-file=docs/requirements.txt pyproject.toml
 #
-alabaster==0.7.13
+alabaster==0.7.16
     # via sphinx
 anyascii==0.3.2
     # via sphinx-autoapi
-astroid==3.0.2
+astroid==3.0.3
     # via sphinx-autoapi
 babel==2.14.0
     # via sphinx
-certifi==2023.11.17
+certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
 colorama==0.4.6
     # via sphinx-autobuild
-docutils==0.18.1
+docutils==0.20.1
     # via
     #   pybtex-docutils
     #   sphinx
@@ -30,7 +30,7 @@ idna==3.6
     # via requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   sphinx
     #   sphinx-autoapi
@@ -38,7 +38,7 @@ latexcodec==2.0.1
     # via pybtex
 livereload==2.6.3
     # via sphinx-autobuild
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
 packaging==23.2
     # via sphinx
@@ -76,17 +76,12 @@ sphinx==7.2.6
     #   sphinx-rtd-theme
     #   sphinx-tabs
     #   sphinx-version-warning
-    #   sphinxcontrib-applehelp
     #   sphinxcontrib-bibtex
-    #   sphinxcontrib-devhelp
-    #   sphinxcontrib-htmlhelp
     #   sphinxcontrib-jquery
-    #   sphinxcontrib-qthelp
-    #   sphinxcontrib-serializinghtml
     #   sphinxemoji
 sphinx-autoapi==3.0.0
     # via sphinx-hoverxref (pyproject.toml)
-sphinx-autobuild==2021.3.14
+sphinx-autobuild==2024.2.4
     # via sphinx-hoverxref (pyproject.toml)
 sphinx-notfound-page==1.0.0
     # via sphinx-hoverxref (pyproject.toml)
@@ -94,17 +89,17 @@ sphinx-prompt==1.8.0
     # via sphinx-hoverxref (pyproject.toml)
 sphinx-rtd-theme==2.0.0
     # via sphinx-hoverxref (pyproject.toml)
-sphinx-tabs==3.4.4
+sphinx-tabs==3.4.5
     # via sphinx-hoverxref (pyproject.toml)
 sphinx-version-warning==1.1.2
     # via sphinx-hoverxref (pyproject.toml)
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.8
     # via sphinx
-sphinxcontrib-bibtex==2.5.0
+sphinxcontrib-bibtex==2.6.2
     # via sphinx-hoverxref (pyproject.toml)
-sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-devhelp==1.0.6
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.4
+sphinxcontrib-htmlhelp==2.0.5
     # via sphinx
 sphinxcontrib-jquery==4.1
     # via
@@ -112,15 +107,15 @@ sphinxcontrib-jquery==4.1
     #   sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-qthelp==1.0.7
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.9
+sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-sphinxemoji==0.2.0
+sphinxemoji==0.3.1
     # via sphinx-hoverxref (pyproject.toml)
 tornado==6.4
     # via livereload
 typing-extensions==4.9.0
     # via astroid
-urllib3==2.1.0
+urllib3==2.2.1
     # via requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,10 @@ doc = [
     "sphinx-version-warning",
     "sphinx-notfound-page",
     "sphinx-autobuild",
-    "sphinxcontrib-bibtex",
+    # versions older than this don't pin
+    # docutils which is necessary for
+    # bibtex html rendering to work properly
+    "sphinxcontrib-bibtex>=2.6.0",
     "sphinxemoji",
 ]
 


### PR DESCRIPTION
Closes #280

Versions lower than 0.20 cause rendering problems in the usage page with the bibliography, see #280.

<!-- readthedocs-preview sphinx-hoverxref start -->
----
📚 Documentation preview 📚: https://sphinx-hoverxref--281.org.readthedocs.build/en/281/

<!-- readthedocs-preview sphinx-hoverxref end -->