### PR TITLE
Fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
         type: string
       sphinx-version:
         type: string
-        default: "50,53,60,62,70,latest"
+        default: "50,53,60,62,70,73,latest"
     steps:
       - checkout
       # Tox >=4 fails with `ValueError: py310-sphinx{18`
@@ -37,6 +37,13 @@ jobs:
       - run-tox:
           version: py310
 
+  py312:
+    docker:
+      - image: 'cimg/python:3.12'
+    steps:
+      - run-tox:
+          version: py312
+
 workflows:
   version: 2
   test:
@@ -44,4 +51,4 @@ workflows:
       - py38
       - py39
       - py310
-
+      - py312

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - run-tox:
           version: py38
+          # Sphinx >=7.2 requires Python 3.9+
+          sphinx-version: "50,53,60,62,70"
 
   py39:
     docker:

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -156,7 +156,7 @@ def test_python_domain_intersphinx(app, status, warning):
         assert chunk in content
 
 
-@pytest.skipif(sys.version_info >= (3, 12), reason="sphinxcontrib.bibtex is not compatible with Python 3.12")
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason="sphinxcontrib.bibtex is not compatible with Python 3.12")
 @pytest.mark.sphinx(
     srcdir=bibtexdomainsrcdir,
     confoverrides={

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -1,4 +1,5 @@
 import re
+import sys
 import pytest
 import sphinx
 import textwrap

--- a/tests/test_htmltag.py
+++ b/tests/test_htmltag.py
@@ -156,6 +156,7 @@ def test_python_domain_intersphinx(app, status, warning):
         assert chunk in content
 
 
+@pytest.skipif(sys.version_info >= (3, 12), reason="sphinxcontrib.bibtex is not compatible with Python 3.12")
 @pytest.mark.sphinx(
     srcdir=bibtexdomainsrcdir,
     confoverrides={

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
   sphinx60: sphinx~=6.0.0
   sphinx62: sphinx~=6.2.0
   sphinx73: sphinx~=7.0.0
-  sphinxlatest: sphinx
+  sphinxlatest: sphinx[test]
 
 commands = pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ isolated_build = True
 
 envlist =
   docs
-  py{38,39,310}-sphinx{50,53,60,62,70,latest}
+  py{38,39,310,312}-sphinx{50,53,60,62,70,73,latest}
 
 [testenv]
 deps =
@@ -16,7 +16,8 @@ deps =
   sphinx53: sphinx~=5.3.0
   sphinx60: sphinx~=6.0.0
   sphinx62: sphinx~=6.2.0
-  sphinx73: sphinx~=7.0.0
+  sphinx70: sphinx~=7.0.0
+  sphinx73: sphinx[test]~=7.3.0
   sphinxlatest: sphinx[test]
 
 commands = pytest {posargs}


### PR DESCRIPTION
The latest version of Sphinx doesn't install some packages that are required for the tests by default.

<!-- readthedocs-preview sphinx-hoverxref start -->
----
📚 Documentation preview 📚: https://sphinx-hoverxref--289.org.readthedocs.build/en/289/

<!-- readthedocs-preview sphinx-hoverxref end -->