### PR TITLE
fix(docs): remove outdated travis build status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build| |PyPI version| |Docs badge| |License|
+|PyPI version| |Docs badge| |License|
 
 sphinx-hoverxref
 ================
@@ -51,9 +51,6 @@ Check out the full documentation at https://sphinx-hoverxref.readthedocs.io/
 .. _Sphinx: https://www.sphinx-doc.org/
 
 
-.. |Build| image:: https://travis-ci.org/readthedocs/sphinx-hoverxref.svg?branch=master
-   :target: https://travis-ci.org/readthedocs/sphinx-hoverxref
-   :alt: Build status
 .. |PyPI version| image:: https://img.shields.io/pypi/v/sphinx-hoverxref.svg
    :target: https://pypi.org/project/sphinx-hoverxref
    :alt: Current PyPI version


### PR DESCRIPTION


<!-- readthedocs-preview sphinx-hoverxref start -->
----
📚 Documentation preview 📚: https://sphinx-hoverxref--291.org.readthedocs.build/en/291/

<!-- readthedocs-preview sphinx-hoverxref end -->