### PR TITLE
Update compatibility of setup_intersphinx module name check with Sphinx-7.4

### DIFF
--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -174,7 +174,7 @@ def setup_intersphinx(app, config):
 
     for listener in app.events.listeners.get('missing-reference'):
         module_name = inspect.getmodule(listener.handler).__name__
-        if module_name == 'sphinx.ext.intersphinx':
+        if module_name.startswith('sphinx.ext.intersphinx'):
             app.disconnect(listener.id)
 
 

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -8,7 +8,6 @@ from sphinx.ext.intersphinx import missing_reference as sphinx_missing_reference
 from sphinx.roles import XRefRole
 from sphinx.util.fileutil import copy_asset
 from sphinx.util import logging
-from packaging.version import parse, Version
 
 from . import __version__
 from .domains import (
@@ -173,14 +172,8 @@ def setup_intersphinx(app, config):
         # does not have hoverxref intersphinx enabled
         return
 
-    # Sphinx-7.4.0 turned the intersphinx module into a package, so target the module according to the version.
-    if parse(sphinx.__version__) >= Version("7.4"):
-        intersphinx_module_listener_name = 'sphinx.ext.intersphinx._resolve'
-    else:
-        intersphinx_module_listener_name = 'sphinx.ext.intersphinx'
     for listener in app.events.listeners.get('missing-reference'):
-        module_name = inspect.getmodule(listener.handler).__name__
-        if module_name == intersphinx_module_listener_name:
+        if listener.handler == sphinx_missing_reference:
             app.disconnect(listener.id)
 
 

--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -8,6 +8,7 @@ from sphinx.ext.intersphinx import missing_reference as sphinx_missing_reference
 from sphinx.roles import XRefRole
 from sphinx.util.fileutil import copy_asset
 from sphinx.util import logging
+from packaging.version import parse, Version
 
 from . import __version__
 from .domains import (
@@ -172,9 +173,14 @@ def setup_intersphinx(app, config):
         # does not have hoverxref intersphinx enabled
         return
 
+    # Sphinx-7.4.0 turned the intersphinx module into a package, so target the module according to the version.
+    if parse(sphinx.__version__) >= Version("7.4"):
+        intersphinx_module_listener_name = 'sphinx.ext.intersphinx._resolve'
+    else:
+        intersphinx_module_listener_name = 'sphinx.ext.intersphinx'
     for listener in app.events.listeners.get('missing-reference'):
         module_name = inspect.getmodule(listener.handler).__name__
-        if module_name.startswith('sphinx.ext.intersphinx'):
+        if module_name == intersphinx_module_listener_name:
             app.disconnect(listener.id)
 
 

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,9 +1,8 @@
-import inspect
 import pytest
 from unittest import mock
 
 from sphinx.events import EventListener
-from sphinx.ext.intersphinx._resolve import missing_reference as intersphinx_missing_reference
+from sphinx.ext.intersphinx import missing_reference as intersphinx_missing_reference
 from hoverxref.extension import missing_reference
 
 from .utils import srcdir

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -34,3 +34,26 @@ def test_dont_fail_non_html_builder(app, status, warning):
     content = open(path).read()
 
     assert app.builder.format == 'latex'
+
+
+@pytest.mark.sphinx(
+    srcdir=srcdir,
+    confoverrides={
+        'hoverxref_domains': ['py'],
+        'hoverxref_intersphinx': ['python'],
+        'hoverxref_auto_ref': True,
+        'extensions': [
+            'sphinx.ext.intersphinx',
+            'hoverxref.extension',
+        ],
+    },
+)
+def test_disconnect_intersphinx_listener(app, status, warning):
+    """Confirm that disconnecting the ``missing-reference`` listener from ``sphinx.ext.intershinx`` is successful."""
+    app.build()
+    listeners = []
+    for listener in app.events.listeners.get('missing-reference'):
+        module_name = inspect.getmodule(listener.handler).__name__
+        if module_name.startswith('sphinx.ext.intersphinx'):
+            listeners.append((module_name, listener))
+    assert not listeners, f"Expected to find zero listeners but found: {listeners}"

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,8 +1,5 @@
 import inspect
-import os
 import pytest
-import shutil
-from unittest import mock
 
 from .utils import srcdir
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ isolated_build = True
 
 envlist =
   docs
-  py{38,39,310,312}-sphinx{50,53,60,62,70,73,latest}
+  py{38,39,310,312}-sphinx{50,53,60,62,70,73,74,latest}
 
 [testenv]
 deps =
@@ -18,6 +18,7 @@ deps =
   sphinx62: sphinx~=6.2.0
   sphinx70: sphinx~=7.0.0
   sphinx73: sphinx[test]~=7.3.0
+  sphinx74: sphinx[test]~=7.4.0
   sphinxlatest: sphinx[test]
 
 commands = pytest {posargs}


### PR DESCRIPTION
Hi hoverxref team,

My tooltips on intersphinx projects stopped working recently. After a while I was able to track down that the break started happening on [`sphinx-7.4.0`](https://www.sphinx-doc.org/en/master/changes/7.4.html).

It seems to be due to `sphinx.ext.intersphinx` becoming a package since that version (through https://github.com/sphinx-doc/sphinx/pull/12178, undocumented in the changelog), so I've updated [`setup_intersphinx`](https://github.com/chrizzFTD/sphinx-hoverxref/blob/65524c4d45a92aa49da5c0fb22483163165c5b25/hoverxref/extension.py#L160) to check for a prefix in the module name, which should preserve backwards compatibility.

Please let me know your thoughts!

To see in action, the `See also` links from [grill.cook.UsdAsset](https://grill--40.org.readthedocs.build/en/40/api.html#grill.cook.UsdAsset):

|   Before this PR  | With this PR |
| ----------- | ----------- |
| ![image](https://github.com/user-attachments/assets/3316fb48-e6b2-465d-9437-1139c71a0941) | ![image](https://github.com/user-attachments/assets/abc5a5c1-6d11-4c48-bef3-aae40dab88e3) |


- Chris

<!-- readthedocs-preview sphinx-hoverxref start -->
----
📚 Documentation preview 📚: https://sphinx-hoverxref--302.org.readthedocs.build/en/302/

<!-- readthedocs-preview sphinx-hoverxref end -->