### PR TITLE
Don't disconnect html-page-context event from sphinx-tabs

### DIFF
--- a/hoverxref/extension.py
+++ b/hoverxref/extension.py
@@ -144,19 +144,6 @@ def setup_domains(app, config):
         app.add_domain(domain, override=True)
 
 
-def setup_sphinx_tabs(app, config):
-    """
-    Disconnect ``update_context`` function from ``sphinx-tabs``.
-
-    Sphinx Tabs removes the CSS/JS from pages that does not use the directive.
-    Although, we need them to use inside the tooltip.
-    """
-    for listener in app.events.listeners.get('html-page-context'):
-        module_name = inspect.getmodule(listener.handler).__name__
-        if module_name == 'sphinx_tabs.tabs':
-            app.disconnect(listener.id)
-
-
 def setup_intersphinx(app, config):
     """
     Disconnect ``missing-reference`` from ``sphinx.ext.intershinx``.
@@ -365,7 +352,6 @@ def setup(app):
     app.connect('config-inited', deprecated_configs_warning)
 
     app.connect('config-inited', setup_domains)
-    app.connect('config-inited', setup_sphinx_tabs)
     app.connect('config-inited', setup_intersphinx)
     app.connect('config-inited', setup_theme)
     app.connect('config-inited', setup_assets_policy)


### PR DESCRIPTION
We are disconnecting the html-page-context event from sphinx-tabs, which was used to delete the static files from html files that didn't use sphinx-tabs. But in https://github.com/executablebooks/sphinx-tabs/pull/198 this was changed to instead decide if the page should have the static files or not.

Since we are removing that event, sphinx-tabs never gets to inject the static files, this breaks sphinx-tabs for projects using hoverxref.

We no longer need to disconnect that signal, since we are overriding the html assets policy to `always`, which sphnx-tabs respects already https://github.com/executablebooks/sphinx-tabs/pull/132 (more than 3 years ago).

<!-- readthedocs-preview sphinx-hoverxref start -->
----
📚 Documentation preview 📚: https://sphinx-hoverxref--318.org.readthedocs.build/en/318/

<!-- readthedocs-preview sphinx-hoverxref end -->