### PR TITLE
Add a note about the deprecation of this extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,15 @@
+.. warning::
+
+   This extension has been deprecated. Users are advised to enable the "Link previews" option in "Settings" > "Addons" > "Link previews"
+   in the Read the Docs admin dashboard for their project to get the same functionality as this extension.
+
+   For more information, please see:
+
+   1. https://docs.readthedocs.com/platform/stable/link-previews.html
+   2. https://about.readthedocs.com/blog/2024/07/addons-by-default/
+
+----
+
 |PyPI version| |Docs badge| |License|
 
 sphinx-hoverxref

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. warning::
 
-   This extension has been deprecated. Users are advised to enable the "Link previews" option in "Settings" > "Addons" > "Link previews"
+   **This extension has been deprecated**. Users are advised to enable the "Link previews" option in "Settings" > "Addons" > "Link previews"
    in the Read the Docs admin dashboard for their project to get the same functionality as this extension.
 
    For more information, please see:


### PR DESCRIPTION
### Description

See #312

This PR updates the README to reflect the current deprecated status of this Sphinx extension, and advises users to switch to the Read the Docs addons.

Unfortunately, the README is in reStructuredText, for which GitHub's admonitions do not render properly. There has been [a workaround that no longer works](https://github.com/orgs/community/discussions/16925#discussioncomment-3279594) due to this issue: https://github.com/github/markup/issues/1682.

I tried to use raw HTML to render the "Warning" as a heading in yellow ochre, but it didn't work that way – the only way to make it more prominent is to convert this document to Markdown.

<!-- readthedocs-preview sphinx-hoverxref start -->
----
📚 Documentation preview 📚: https://sphinx-hoverxref--337.org.readthedocs.build/en/337/

<!-- readthedocs-preview sphinx-hoverxref end -->